### PR TITLE
Add YouTube to footer of docusaurus.config.js

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -267,6 +267,10 @@ const config = {
                 label: 'Join us on Slack',
                 href: 'https://cloud-native.slack.com/archives/C0344AANLA1',
               },
+               {
+                label: 'YouTube',
+                href: 'https://www.youtube.com/@openfeature834',
+              },
             ],
           },
           {


### PR DESCRIPTION
## This PR
Adds the OF YT page to the Community section of the footer