### PR TITLE
feat: Add Python to docs

### DIFF
--- a/docs/reference/concepts/01-evaluation-api.mdx
+++ b/docs/reference/concepts/01-evaluation-api.mdx
@@ -63,6 +63,17 @@ OpenFeatureAPI::getInstance()->setProvider(new YourProviderOfChoice());
 ```
 
 </TabItem>
+
+<TabItem value="python" label="Python">
+
+```php
+from open_feature import open_feature_api
+from open_feature.provider.no_op_provider import NoOpProvider
+
+open_feature_api.set_provider(NoOpProvider())
+```
+
+</TabItem>
 </Tabs>
 
 ## Creating a client
@@ -109,6 +120,15 @@ $client = OpenFeatureAPI::getInstance()->getClient("my-app");
 ```
 
 </TabItem>
+
+<TabItem value="python" label="Python">
+
+```php
+open_feature_client = open_feature_api.get_client()
+```
+
+</TabItem>
+
 </Tabs>
 
 ## Flag Evaluation
@@ -214,6 +234,20 @@ $floatValue = $client->getFloatValue("floatFlag", 0.9, null, null);
 
 // get an object value
 $objectValue = $client->getObjectValue("objectFlag", $myObjectInstance, null, null);
+```
+
+</TabItem>
+
+<TabItem value="python" label="Python">
+
+```python
+# Depending on the flag type, use one of the methods below
+flag_key = "PROVIDER_FLAG"
+boolean_result = open_feature_client.get_boolean_value(key=flag_key,default_value=False)
+integer_result = open_feature_client.get_integer_value(key=flag_key,default_value=-1)
+float_result = open_feature_client.get_float_value(key=flag_key,default_value=-1)
+string_result = open_feature_client.get_string_value(key=flag_key,default_value="")
+object_result = open_feature_client.get_object_value(key=flag_key,default_value={})
 ```
 
 </TabItem>
@@ -330,6 +364,29 @@ $floatDetails = $client->getFloatDetails("floatFlag", 0.9, null, null);
 
 // get details of an object evaluation
 $objectDetails = $client->getObjectDetails("objectFlag", $myObjectInstance, null, null);
+```
+
+</TabItem>
+
+<TabItem value="python" label="Python">
+
+```php
+flag_key = "PROVIDER_FLAG"
+
+// get details of a boolean evaluation
+boolean_details = open_feature_client.get_boolean_details(key=flag_key,default_value=False,evaluation_context={},flag_evaluation_options={})
+
+// get details of a string evaluation
+string_details = open_feature_client.get_string_details(key=flag_key,default_value="",evaluation_context={},flag_evaluation_options={})
+
+// get details of an integer evaluation
+int_details = open_feature_client.get_integer_details(key=flag_key,default_value=1,evaluation_context={},flag_evaluation_options={})
+
+// get details of a float evaluation
+float_details = open_feature_client.get_float_details(key=flag_key,default_value=0.9,evaluation_context={},flag_evaluation_options={})
+
+// get details of an object evaluation
+object_details = open_feature_client.get_object_details(key=flag_key,default_value={},evaluation_context={},flag_evaluation_options={})
 ```
 
 </TabItem>

--- a/docs/reference/concepts/02-provider.mdx
+++ b/docs/reference/concepts/02-provider.mdx
@@ -313,6 +313,76 @@ class MyFeatureProvider implements Provider
 
 </TabItem>
 
+<TabItem value="python" label="Python">
+
+```python
+import typing
+
+from open_feature.evaluation_context.evaluation_context import EvaluationContext
+from open_feature.flag_evaluation.reason import Reason
+from open_feature.flag_evaluation.resolution_details import FlagResolutionDetails
+from open_feature.hooks.hook import Hook
+from open_feature.provider.metadata import Metadata
+from open_feature.provider.my_provider_metadata import MyProviderMetadata
+from open_feature.provider.provider import AbstractProvider
+
+
+class MyProvider(AbstractProvider):
+    def get_metadata(self) -> Metadata:
+        return MyProviderMetadata()
+
+    def get_provider_hooks(self) -> typing.List[Hook]:
+        return []
+
+    def resolve_boolean_details(
+        self,
+        flag_key: str,
+        default_value: bool,
+        evaluation_context: typing.Optional[EvaluationContext] = None,
+    ) -> FlagResolutionDetails[bool]:
+        
+        # Code to retrieve details for boolean-type flags
+
+
+    def resolve_string_details(
+        self,
+        flag_key: str,
+        default_value: str,
+        evaluation_context: typing.Optional[EvaluationContext] = None,
+    ) -> FlagResolutionDetails[str]:
+        
+        # Code to retrieve details for string-type flags
+
+    def resolve_integer_details(
+        self,
+        flag_key: str,
+        default_value: int,
+        evaluation_context: typing.Optional[EvaluationContext] = None,
+    ) -> FlagResolutionDetails[int]:
+        
+        # Code to retrieve details for integer-type flags
+
+    def resolve_float_details(
+        self,
+        flag_key: str,
+        default_value: float,
+        evaluation_context: typing.Optional[EvaluationContext] = None,
+    ) -> FlagResolutionDetails[float]:
+        
+        # Code to retrieve details for float-type flags
+
+    def resolve_object_details(
+        self,
+        flag_key: str,
+        default_value: typing.Union[dict, list],
+        evaluation_context: typing.Optional[EvaluationContext] = None,
+    ) -> FlagResolutionDetails[typing.Union[dict, list]]:
+
+        # Code to retrieve details for object-type flags
+```
+
+</TabItem>
+
 </Tabs>
 
 ### Checklist

--- a/docs/reference/concepts/03-evaluation-context.mdx
+++ b/docs/reference/concepts/03-evaluation-context.mdx
@@ -125,6 +125,19 @@ $boolValue = $client->getBooleanValue("boolFlag", false, $context);
 ```
 
 </TabItem>
+
+<TabItem value="python" label="Python">
+
+```python
+boolean_value = open_feature_client.get_boolean_value(
+    key="my_flag",
+    default_value=False,
+    evaluation_context={ "foo": "bar", "foo2": "bar2" },
+    flag_evaluation_options={}
+);
+```
+
+</TabItem>
 </Tabs>
 
 ### Context merging

--- a/docs/reference/concepts/04-hooks.mdx
+++ b/docs/reference/concepts/04-hooks.mdx
@@ -101,6 +101,14 @@ $value = $client->getBooleanValue("boolFlag", false, $context, new EvaluationOpt
 ```
 
 </TabItem>
+<TabItem value="python" label="Python">
+
+```python
+# Hooks are not yet supported in Python
+# Help us and contribute the code!
+```
+
+</TabItem>
 </Tabs>
 
 ## Flag Evaluation Life-Cycle
@@ -289,6 +297,15 @@ class MyHook implements Hook
     }
 }
 
+```
+
+</TabItem>
+
+<TabItem value="python" label="Python">
+
+```python
+# Hooks are not yet supported in Python
+# Help us and contribute the code!
 ```
 
 </TabItem>

--- a/docs/reference/technologies/server/python.mdx
+++ b/docs/reference/technologies/server/python.mdx
@@ -1,0 +1,11 @@
+# Python
+
+ℹ️ The OpenFeature Python SDK is looking for a maintainer.
+
+If you would like to get involved, we'd love to have you!
+
+Please reach out via [the CNCF Slack channel](/community/#discussions).
+
+import { PythonFeatures } from '@site/src/components/ServerTechnologiesFeatures';
+
+<PythonFeatures/>

--- a/src/components/ServerTechnologiesFeatures/PythonFeatures/index.tsx
+++ b/src/components/ServerTechnologiesFeatures/PythonFeatures/index.tsx
@@ -1,0 +1,32 @@
+import { faPython } from '@fortawesome/free-brands-svg-icons';
+import React from 'react';
+import { OpenFeatureTechnologiesPage } from '../../custom/OpenFeatureTechnologiesPage';
+import FlagdSvg from '@site/static/img/flagd-no-fill.svg';
+import SplitSvg from '@site/static/img/split-no-fill.svg';
+import CloudbeesSvg from '@site/static/img/cloudbees-no-fill.svg';
+import OTelSvg from '@site/static/img/otel-no-fill.svg';
+import DatadogSvg from '@site/static/img/datadog-no-fill.svg';
+import CheckCircle from '@site/static/img/check-circle-no-fill.svg';
+
+export class PythonFeatures extends React.Component {
+  override render() {
+    return (
+      <OpenFeatureTechnologiesPage
+        technology="Python"
+        iconDefinition={faPython}
+        sdkRepoLink={{
+          title: 'Github repository',
+          href: 'https://github.com/open-feature/python-sdk',
+        }}
+        artifact={{
+          title: 'OpenFeature on Pypi',
+          href: 'https://pypi.org/project/openfeature-sdk/',
+          instruction: 'pip install openfeature-sdk==0.0.9',
+          codeBlockLanguage: 'shell',
+        }}
+        providers={[]}
+        hooks={[]}
+      />
+    );
+  }
+}

--- a/src/components/ServerTechnologiesFeatures/index.ts
+++ b/src/components/ServerTechnologiesFeatures/index.ts
@@ -4,3 +4,4 @@ export * from './JavaFeatures';
 export * from './GoFeatures';
 export * from './DotnetFeatures';
 export * from './PhpFeatures';
+export * from './PythonFeatures';

--- a/src/components/ServerTechnologiesFeatures/server-technologies-table.tsx
+++ b/src/components/ServerTechnologiesFeatures/server-technologies-table.tsx
@@ -1,4 +1,4 @@
-import { faGolang, faJava, faPhp, faSquareJs } from '@fortawesome/free-brands-svg-icons';
+import { faGolang, faJava, faPhp, faSquareJs, faPython } from '@fortawesome/free-brands-svg-icons';
 import CSharpNoFillSvg from '@site/static/img/c-sharp-no-fill.svg';
 import React from 'react';
 import { OpenFeatureComponentTable } from '../custom/OpenFeatureComponentTable';
@@ -38,6 +38,12 @@ export class ServerTechnologiesTable extends React.Component {
             iconDefinition: faPhp,
             title: 'PHP',
             description: 'SDK and components for PHP',
+          },
+          {
+            href: '/docs/reference/technologies/server/python',
+            iconDefinition: faPython,
+            title: 'Python',
+            description: 'SDK and components for Python',
           },
         ]}
       />


### PR DESCRIPTION
## This PR
- Adds Python to the website
- Has dummy placeholder text where things are unsupported / unknown

### Justification

If Python is visible on the site (albeit that the Python SDK is not yet spec-compliant) it may drum up support and advertise the need for a Python maintainer.

In short, rather than the answer being "OpenFeature just doesn't support Python because it isn't listed", it'll shift the conversation to "OpenFeature can and does support Python, but it needs some work (and perhaps we can help".