### PR TITLE
add configcat go provider

### DIFF
--- a/src/components/ServerTechnologiesFeatures/GoFeatures/index.tsx
+++ b/src/components/ServerTechnologiesFeatures/GoFeatures/index.tsx
@@ -10,6 +10,7 @@ import FliptSvg from '@site/static/img/flipt-no-fill.svg';
 import GoFeatureFlagNoFillSvg from '@site/static/img/goff-no-fill.svg';
 import FlagsmithNoFill from '@site/static/img/flagsmith-no-fill.svg';
 import LaunchDarklyNoFill from '@site/static/img/launchdarkly-no-fill.svg';
+import ConfigCatSvg from '@site/static/img/config-cat-no-fill.svg';
 
 export class GoFeatures extends React.Component {
   override render() {
@@ -73,6 +74,13 @@ export class GoFeatures extends React.Component {
             description: 'A community-maintained provider for LaunchDarkly',
             href: 'https://github.com/open-feature/go-sdk-contrib/tree/main/providers/launchdarkly',
             svg: LaunchDarklyNoFill,
+            vendorOfficial: false,
+          },
+          {
+            title: 'ConfigCat Provider',
+            description: 'A community-maintained provider for ConfigCat',
+            href: 'https://github.com/open-feature/go-sdk-contrib/tree/main/providers/configcat',
+            svg: ConfigCatSvg,
             vendorOfficial: false,
           },
         ]}

--- a/src/datasets/providers/configcat.ts
+++ b/src/datasets/providers/configcat.ts
@@ -9,5 +9,9 @@ export const ConfigCat: Provider = {
       vendorOfficial: false,
       href: 'https://www.npmjs.com/package/@openfeature/config-cat-provider',
     },
+    Go: {
+      vendorOfficial: false,
+      href: 'https://github.com/open-feature/go-sdk-contrib/tree/main/providers/configcat',
+    },
   },
 };


### PR DESCRIPTION
## This PR

- adds the ConfigCat Go provider to the docs

### Notes

Thank you, @rcowe, for your contribution.

### Follow-up Tasks

The provider configuration should be in a central location. A [follow-up issue](https://github.com/open-feature/openfeature.dev/issues/154) will consolidate the provider and hook data set.

### How to test

Open the preview and look for the ConfigCat provider on the ecosystem page and under the Go SDK.
