### PR TITLE
add Jake Van Vorhis to authors.yml

### DIFF
--- a/blog/authors.yml
+++ b/blog/authors.yml
@@ -51,3 +51,9 @@ liran2000:
   title: Software Developer
   url: https://liran2000.github.io
   image_url: https://liran2000.github.io/images/liran.jpg
+
+jakedoublev:
+  name: Jake Van Vorhis
+  title: Senior Software Engineer
+  url: https://github.com/jakedoublev
+  image_url: https://github.com/jakedoublev.png


### PR DESCRIPTION
## This PR
adds Jake Van Vorhis (@jakedoublev) to the blog authors list (for an upcoming blog post).