### PR TITLE
feat: add google analytics

### DIFF
--- a/docusaurus-ts-config.ts
+++ b/docusaurus-ts-config.ts
@@ -317,6 +317,13 @@ const config: Config = {
       },
     ],
     'docusaurus-plugin-sass',
+    [
+      '@docusaurus/plugin-google-gtag',
+      {
+        trackingID: 'G-ZG0JSPYJXZ',
+        anonymizeIP: true,
+      },
+    ],
   ],
   themeConfig,
 };


### PR DESCRIPTION
## This PR

- adds google analytics with anonymized IP enabled

### Notes

Access to the account is available to the Governance Committee and the CNCF. Read access can be granted on case-by-case bases by contacting a member of the GC.

