### PR TITLE
Docs/diff highlight

### DIFF
--- a/docs/tutorials/getting-started/node.mdx
+++ b/docs/tutorials/getting-started/node.mdx
@@ -123,9 +123,10 @@ npm install @openfeature/js-sdk
 
 Update `index.js` to import the SDK.
 
-```diff
+```js
 const express = require('express');
-+ const { OpenFeature } = require('@openfeature/js-sdk');
+// diff-add 
+const { OpenFeature } = require('@openfeature/js-sdk');
 ```
 
 </TabItem>
@@ -134,9 +135,10 @@ const express = require('express');
 
 Update `index.ts` to import the SDK.
 
-```diff
+```ts
 import express from "express";
-+ import { OpenFeature } from "@openfeature/js-sdk";
+// diff-add
+import { OpenFeature } from "@openfeature/js-sdk";
 ```
 
 </TabItem>
@@ -144,10 +146,10 @@ import express from "express";
 
 Once you've imported `OpenFeature`, a new client can be created.
 
-```diff
+```js
 const port = 8080;
-
-+ const client = OpenFeature.getClient();
+// diff-add
+const client = OpenFeature.getClient();
 ```
 
 The client can now be used to get a feature flag value.
@@ -155,18 +157,23 @@ In this case, we'll get a `boolean` value using the `welcome-message` [flag key]
 
 The second argument is the fallback value, which is returned if there's abnormal behavior.
 
-```diff
-- app.get("/", (_, res) => {
+```js
+// diff-remove
+app.get("/", (_, res) => {
+// diff-add-block-start
 + app.get("/", async (_, res) => {
 +   const showWelcomeMessage = await client.getBooleanValue("welcome-message", false);
 +   if (showWelcomeMessage) {
 +     res.send("Express + TypeScript + OpenFeature Server");
 +   } else {
+// diff-add-block-end
+// diff-remove
 -   res.send("Express + TypeScript Server");
+// diff-add-block-start
 +     res.send("Express + TypeScript Server");
 +   }
+// diff-add-block-end
 });
-
 ```
 
 ### Step 4: Run the application
@@ -216,9 +223,10 @@ npm install @openfeature/flagd-provider
 
 Now, update `index.js` to import the `flagd provider`.
 
-```diff
+```js
 const { OpenFeature } = require('@openfeature/js-sdk');
-+ const { FlagdProvider } = require('@openfeature/flagd-provider');
+// diff-add
+const { FlagdProvider } = require('@openfeature/flagd-provider');
 ```
 
 </TabItem>
@@ -227,9 +235,10 @@ const { OpenFeature } = require('@openfeature/js-sdk');
 
 Now, update `index.ts` to import the `flagd provider`.
 
-```diff
+```ts
 import { OpenFeature } from "@openfeature/js-sdk";
-+ import { FlagdProvider } from "@openfeature/flagd-provider";
+// diff-add
+import { FlagdProvider } from "@openfeature/flagd-provider";
 ```
 
 </TabItem>
@@ -237,10 +246,11 @@ import { OpenFeature } from "@openfeature/js-sdk";
 
 Finally, we need to register the provider with OpenFeature.
 
-```diff
+```js
 const port = 8080;
 
-+ OpenFeature.setProvider(new FlagdProvider());
+// diff-add
+OpenFeature.setProvider(new FlagdProvider());
 const client = OpenFeature.getClient();
 ```
 

--- a/docs/tutorials/getting-started/node.mdx
+++ b/docs/tutorials/getting-started/node.mdx
@@ -161,17 +161,17 @@ The second argument is the fallback value, which is returned if there's abnormal
 // diff-remove
 app.get("/", (_, res) => {
 // diff-add-block-start
-+ app.get("/", async (_, res) => {
-+   const showWelcomeMessage = await client.getBooleanValue("welcome-message", false);
-+   if (showWelcomeMessage) {
-+     res.send("Express + TypeScript + OpenFeature Server");
-+   } else {
+app.get("/", async (_, res) => {
+  const showWelcomeMessage = await client.getBooleanValue("welcome-message", false);
+  if (showWelcomeMessage) {
+    res.send("Express + TypeScript + OpenFeature Server");
+  } else {
 // diff-add-block-end
 // diff-remove
--   res.send("Express + TypeScript Server");
+  res.send("Express + TypeScript Server");
 // diff-add-block-start
-+     res.send("Express + TypeScript Server");
-+   }
+    res.send("Express + TypeScript Server");
+  }
 // diff-add-block-end
 });
 ```

--- a/docusaurus-ts-config.ts
+++ b/docusaurus-ts-config.ts
@@ -162,6 +162,25 @@ const themeConfig: ThemeCommonConfig & AlgoliaThemeConfig = {
   prism: {
     theme: oceanicNext,
     additionalLanguages: ['java', 'csharp', 'powershell', 'php'],
+    magicComments: [
+      {
+        className: 'theme-code-block-highlighted-line',
+        line: 'highlight-next-line',
+        block: { start: 'highlight-start', end: 'highlight-end' },
+      },
+      {
+        className: 'code-block-diff-remove-line',
+        line: 'diff-remove',
+        block: { start: 'diff-remove-block-start', end: 'diff-remove-block-end' },
+      },
+      {
+        className: 'code-block-diff-add-line',
+        line: 'diff-add',
+        block: {
+          start: 'diff-add-block-start', end: 'diff-add-block-end'
+        },
+      },
+    ],
   },
 };
 

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -46,6 +46,22 @@
   text-align: left;
 }
 
+.code-block-diff-remove-line{
+  background-color: #ff00001f;
+  display: block;
+  margin: 0 calc(-1 * var(--ifm-pre-padding));
+  padding: 0 var(--ifm-pre-padding);
+  border-left: 3px solid #ff000080;
+}
+
+.code-block-diff-add-line{
+  background-color: #00ff001f;
+  display: block;
+  margin: 0 calc(-1 * var(--ifm-pre-padding));
+  padding: 0 var(--ifm-pre-padding);
+  border-left: 3px solid #00ff0080;
+}
+
 /* Shifts the badges left to look nicer in the docs */
 .github-badges {
   text-align: start;


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->
- Adds [Custom Magic Comments](https://docusaurus.io/docs/markdown-features/code-blocks#custom-magic-comments) to provide diff highlights
- Adds diff and syntax highlight for the Node.js getting started guide

### Related Issues
N/A

### Notes
While following the `getting started` guide I got a bit uncomfortable with all the "-" and "+" used for the diffs and lack of syntax highlight. I had a good experience recently with `backstage.io` and decided to port the current code blocks to a format that is similar to theirs. 

### Follow-up Tasks
- Porting the rest of the getting started guides with the diffs highlights (if it gets accepted)

### How to test
It can be run locally, but before and after images are provided bellow.

#### Before

![image](https://github.com/open-feature/openfeature.dev/assets/10711482/3619e5fc-b87a-4ed1-b4cf-548224767f24)

#### After

![image](https://github.com/open-feature/openfeature.dev/assets/10711482/1f70f36e-f492-4a90-b30e-fc86ea15d860)


