### PR TITLE
docs: add event description to intro

### DIFF
--- a/docs/reference/concepts/05-events.mdx
+++ b/docs/reference/concepts/05-events.mdx
@@ -19,7 +19,6 @@ Handlers attached to a client will run only when the provider bound with that cl
 
 Handlers are passed an [event details](/specification/types#event-details) structure, which contains data about the event, including a list of keys that have changed (if applicable and available).
 
-<!-- TODO: add more languages when completed -->
 <Tabs groupId="code">
 <TabItem value="js" label="TypeScript">
 

--- a/docs/reference/concepts/05-events.mdx
+++ b/docs/reference/concepts/05-events.mdx
@@ -75,14 +75,14 @@ Generally, the associated event details will indicate which flag (or flags) have
 
 ### PROVIDER_ERROR
 
-The provider signalled an error.
+The provider signaled an error.
 
 If a provider becomes unavailable, evaluations will typically default.
 Handlers associated with `PROVIDER_ERROR` events can be used to alert monitoring systems about the provider failure, or enable custom fallback mechanisms.
 
 ### PROVIDER_STALE
 
-The provider's cached state is not longer valid and may not be up-to-date with the source of truth.
+The provider's cached state is no longer valid and may not be up-to-date with the source of truth.
 
 Some providers maintain a connection to a management system, but are also tolerate of disconnection.
 The `PROVIDER_STALE` indicates this situation.

--- a/docs/reference/intro.mdx
+++ b/docs/reference/intro.mdx
@@ -72,3 +72,7 @@ Providers might wrap a vendor SDK, call a bespoke flag evaluation REST API, or e
 
 [Hooks](./concepts/04-hooks.mdx) are a mechanism that allow for the addition of arbitrary behavior at various points in the _flag evaluation life-cycle_.
 Hooks let you extend the OpenFeature SDK, adding functionality such as validating a resolved flag value, modifying or adding data to the evaluation context, logging, telemetry, and tracking.
+
+### Events
+
+[Events](./concepts/05-events.mdx) enable the ability to react to state changes in the provider or underlying flag management system. These include changes in provider readiness, error status, or perhaps most interestingly, flag configuration changes.


### PR DESCRIPTION
## This PR

- adds event description to intro

### Notes

Updated the event file extension to `.mdx` to match the other files.

Signed-off-by: Michael Beemer <beeme1mr@users.noreply.github.com>
