### PR TITLE
Adding DevCycle Java Provider

### DIFF
--- a/src/datasets/providers/devcycle.ts
+++ b/src/datasets/providers/devcycle.ts
@@ -14,7 +14,7 @@ export const DevCycle: Provider = {
     {
       technology: 'Java',
       vendorOfficial: true,
-      href: 'https://github.com/DevCycleHQ/java-server-sdk/',
+      href: 'https://github.com/DevCycleHQ/java-server-sdk/#openfeature-support',
       category: ['Server'],
     },
   ],

--- a/src/datasets/providers/devcycle.ts
+++ b/src/datasets/providers/devcycle.ts
@@ -11,5 +11,11 @@ export const DevCycle: Provider = {
       href: 'https://www.npmjs.com/package/@devcycle/openfeature-nodejs-provider',
       category: ['Server'],
     },
+    {
+      technology: 'Java',
+      vendorOfficial: true,
+      href: 'https://github.com/DevCycleHQ/java-server-sdk/',
+      category: ['Server'],
+    },
   ],
 };


### PR DESCRIPTION
## This PR
<!-- add the description of the PR here -->
Adding a reference to the DevCycle Java Provider to the Openfeature.dev site so that it appears in the ecosystem of providers

### Related Issues

Fixes #266

### Notes

The DevCycle Java Provider is built directly into the DevCycle Java SDK and not a separate repo, so the link goes to the `DevCycleHQ/java-server-sdk` repo

### How to test

* Run `yarn start`
* Go to the Ecosystems page
* Filter by DevCycle to confirm the Java provider appears

