### PR TITLE
Add Go and .NET DevCycle providers

### DIFF
--- a/src/datasets/providers/devcycle.ts
+++ b/src/datasets/providers/devcycle.ts
@@ -17,5 +17,17 @@ export const DevCycle: Provider = {
       href: 'https://github.com/DevCycleHQ/java-server-sdk/#openfeature-support',
       category: ['Server'],
     },
+    {
+      technology: 'Go',
+      vendorOfficial: true,
+      href: 'https://github.com/DevCycleHQ/go-server-sdk#openfeature-support',
+      category: ['Server'],
+    },
+    {
+      technology: '.NET',
+      vendorOfficial: true,
+      href: 'https://docs.devcycle.com/sdk/server-side-sdks/dotnet/dotnet-openfeature',
+      category: ['Server'],
+    },
   ],
 };

--- a/src/datasets/providers/devcycle.ts
+++ b/src/datasets/providers/devcycle.ts
@@ -8,19 +8,19 @@ export const DevCycle: Provider = {
     {
       technology: 'JavaScript',
       vendorOfficial: true,
-      href: 'https://www.npmjs.com/package/@devcycle/openfeature-nodejs-provider',
+      href: 'https://docs.devcycle.com/sdk/server-side-sdks/node/node-openfeature',
       category: ['Server'],
     },
     {
       technology: 'Java',
       vendorOfficial: true,
-      href: 'https://github.com/DevCycleHQ/java-server-sdk/#openfeature-support',
+      href: 'https://docs.devcycle.com/sdk/server-side-sdks/java-local/java-local-openfeature',
       category: ['Server'],
     },
     {
       technology: 'Go',
       vendorOfficial: true,
-      href: 'https://github.com/DevCycleHQ/go-server-sdk#openfeature-support',
+      href: 'https://docs.devcycle.com/sdk/server-side-sdks/go/go-openfeature',
       category: ['Server'],
     },
     {


### PR DESCRIPTION
## This PR
Adding a reference to the DevCycle Go and .NET Providers to the Openfeature.dev site so that they appear in the ecosystem of providers.


### Related Issues
I didn't create an issue for either of these providers, but I can do that if that's a necessary step for adding them.

### Notes

### How to test
- Run `yarn start`
- Go to the Ecosystems page
- Filter by DevCycle to confirm the Go and .NET providers appear

