### PR TITLE
chore: fix typo and indent in Java tutorial

### DIFF
--- a/docs/reference/technologies/server/java.mdx
+++ b/docs/reference/technologies/server/java.mdx
@@ -89,11 +89,11 @@ public void example(){
 
     // flags defined in memory
     Map<String, Flag<?>> myFlags = new HashMap<>();
-        flags.put("v2_enabled", Flag.builder()
-            .variant("on", true)
-            .variant("off", false)
-            .defaultVariant("on")
-            .build());
+    myFlags.put("v2_enabled", Flag.builder()
+        .variant("on", true)
+        .variant("off", false)
+        .defaultVariant("on")
+        .build());
 
     // configure a provider
     OpenFeatureAPI api = OpenFeatureAPI.getInstance();


### PR DESCRIPTION
## This PR

- Fix typo in https://openfeature.dev/docs/reference/technologies/server/java#usage
- Align indent


