### PR TITLE
Fix the URL for list of available PHP providers

### DIFF
--- a/docs/reference/technologies/server/php.mdx
+++ b/docs/reference/technologies/server/php.mdx
@@ -149,7 +149,7 @@ class MyClass
 ### Providers
 
 [Providers](/docs/reference/concepts/provider) are an abstraction between a flag management system and the OpenFeature SDK.
-Look [here](/ecosystem?instant_search%5BrefinementList%5D%5Btype%5D%5B0%5D=Provider&instant_search%5BrefinementList%5D%5Btechnology%5D%5B0%5D=php) for a complete list of available providers.
+Look [here](/ecosystem?instant_search%5BrefinementList%5D%5Btype%5D%5B0%5D=Provider&instant_search%5BrefinementList%5D%5Btechnology%5D%5B0%5D=PHP) for a complete list of available providers.
 If the provider you're looking for hasn't been created yet, see the [develop a provider](#develop-a-provider) section to learn how to build it yourself.
 
 Once you've added a provider as a dependency, it can be registered with OpenFeature like this:


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
- adjusts the URL used to link to the list of available PHP providers.

### Related Issues
n/a

### Notes
The filter parameters in the Ecosystem page seem to be case-sensitive

### Follow-up Tasks
none

### How to test
Issue can be confirmed at https://openfeature.dev/docs/reference/technologies/server/php#providers - check the "Look _here_" link.

