### PR TITLE
docs: improve syntax highlighting for tutorial code examples

### DIFF
--- a/docs/tutorials/getting-started/go.mdx
+++ b/docs/tutorials/getting-started/go.mdx
@@ -82,46 +82,52 @@ go mod tidy
 
 Next, let's add logic to customize the response message based on the `boolean` [flag key][flag-key] `welcome-message`.
 
-```diff
+```go
 package main
 
- import (
-+       "context"
-        "github.com/gin-gonic/gin"
-+       "github.com/open-feature/go-sdk/pkg/openfeature"
-        "net/http"
- )
+import (
+// diff-add
+      "context"
+       "github.com/gin-gonic/gin"
+// diff-add
+       "github.com/open-feature/go-sdk/pkg/openfeature"
+       "net/http"
+)
 
-  const defaultMessage = "Hello!"
-+ const newWelcomeMessage = "Hello, welcome to this OpenFeature-enabled website!"
+const defaultMessage = "Hello!"
+const newWelcomeMessage = "Hello, welcome to this OpenFeature-enabled website!"
 
- func main() {
-+       // Initialize OpenFeature client
-+       client := openfeature.NewClient("GoStartApp")
-+
-        // Initialize Go Gin
-        engine := gin.Default()
+func main() {
+       // Initialize OpenFeature client
+       client := openfeature.NewClient("GoStartApp")
 
-        // Setup a simple endpoint
-        engine.GET("/hello", func(c *gin.Context) {
--               c.JSON(http.StatusOK, defaultMessage)
--               return
+       // Initialize Go Gin
+       engine := gin.Default()
 
-+               // Evaluate welcome-message feature flag
-+               welcomeMessage, _ := client.BooleanValue(
-+                       context.Background(), "welcome-message", false, openfeature.EvaluationContext{},
-+               )
-+
-+               if welcomeMessage {
-+                       c.JSON(http.StatusOK, newWelcomeMessage)
-+                       return
-+               } else {
-+                       c.JSON(http.StatusOK, defaultMessage)
-+                       return
-+               }
-        })
+       // Setup a simple endpoint
+       engine.GET("/hello", func(c *gin.Context) {
+// diff-remove-block-start
+               c.JSON(http.StatusOK, defaultMessage)
+               return
 
-        engine.Run()
+// diff-remove-block-end
+// diff-add-block-start
+               // Evaluate welcome-message feature flag
+               welcomeMessage, _ := client.BooleanValue(
+                       context.Background(), "welcome-message", false, openfeature.EvaluationContext{},
+               )
+
+               if welcomeMessage {
+                       c.JSON(http.StatusOK, newWelcomeMessage)
+                       return
+               } else {
+                       c.JSON(http.StatusOK, defaultMessage)
+                       return
+               }
+// diff-add-block-end
+       })
+
+       engine.Run()
 ```
 
 To add OpenFeature SDK dependency to the application, run the following commands.
@@ -149,21 +155,24 @@ Now you can visit the url [http://localhost:8080/hello](http://localhost:8080/he
 
 Now, let's make the required code changes in our application.
 
-```diff
- import (
-        "context"
-        "github.com/gin-gonic/gin"
-+       flagd "github.com/open-feature/go-sdk-contrib/providers/flagd/pkg"
-        "github.com/open-feature/go-sdk/pkg/openfeature"
-        "net/http"
- )
+```go
+import (
+       "context"
+       "github.com/gin-gonic/gin"
+// diff-add
+       flagd "github.com/open-feature/go-sdk-contrib/providers/flagd/pkg"
+       "github.com/open-feature/go-sdk/pkg/openfeature"
+       "net/http"
+)
 
- func main() {
-+       // Use flagd as the OpenFeature provider
-+       openfeature.SetProvider(flagd.NewProvider())
-+
-        // Initialize OpenFeature client
-        client := openfeature.NewClient("GoStartApp")
+func main() {
+// diff-add-block-start
+       // Use flagd as the OpenFeature provider
+       openfeature.SetProvider(flagd.NewProvider())
+
+// diff-add-block-end
+       // Initialize OpenFeature client
+       client := openfeature.NewClient("GoStartApp")
 ```
 
 Then, let's add `flagd provider` dependency with following commands.

--- a/docs/tutorials/getting-started/java.mdx
+++ b/docs/tutorials/getting-started/java.mdx
@@ -178,10 +178,11 @@ Now you can visit the url [http://localhost:8080/hello](http://localhost:8080/he
 
 Finally, let's add the required code change to `OpenFeatureBeans.java` class.
 
-```diff
+```java
 package com.demo;
 
-+ import dev.openfeature.contrib.providers.flagd.FlagdProvider;
+// diff-add
+import dev.openfeature.contrib.providers.flagd.FlagdProvider;
 import dev.openfeature.sdk.OpenFeatureAPI;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -192,10 +193,12 @@ public class OpenFeatureBeans {
     @Bean
     public OpenFeatureAPI OpenFeatureAPI() {
         final OpenFeatureAPI openFeatureAPI = OpenFeatureAPI.getInstance();
-        
-+        // Use flagd as the OpenFeature provider and use default configurations
-+        openFeatureAPI.setProvider(new FlagdProvider());
 
+// diff-add-block-start
+        // Use flagd as the OpenFeature provider and use default configurations
+        openFeatureAPI.setProvider(new FlagdProvider());
+
+// diff-add-block-end
         return openFeatureAPI;
     }
 }

--- a/docs/tutorials/getting-started/php.mdx
+++ b/docs/tutorials/getting-started/php.mdx
@@ -61,10 +61,11 @@ composer require open-feature/sdk
 
 Update `routes/api.php` to import the SDK
 
-```diff
+```php
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
-+ use OpenFeature\OpenFeatureAPI;
+// diff-add
+use OpenFeature\OpenFeatureAPI;
 ```
 
 The client can now be used to get a feature flag value.
@@ -72,15 +73,16 @@ In this case, we'll get a boolean value using the welcome-message flag key.
 
 The second argument is the fallback value, which is returned if there's abnormal behavior.
 
-```diff
+```php
 Route::get('/hello', function () {
--    return response()->json(['message' => 'Hello, World!']);
-+    $api = OpenFeatureAPI::getInstance();
-+    $client = $api->getClient();
-+    if($client->getBooleanValue("welcome-message", false)){
-+        return response()->json(['message' => 'Hello, World! open feature']);
-+    }
-+    return response()->json(['message' => 'Hello, World!']);
+// diff-add-block-start
+    $api = OpenFeatureAPI::getInstance();
+    $client = $api->getClient();
+    if($client->getBooleanValue("welcome-message", false)){
+        return response()->json(['message' => 'Hello, World! open feature']);
+    }
+// diff-add-block-end
+    return response()->json(['message' => 'Hello, World!']);
 });
 ```
 
@@ -116,29 +118,33 @@ Now let's make the required code changes in our application.
 
 Now, update `routes/api.php` to import the `flagd provider`.
 
-```diff
+```php
 use OpenFeature\OpenFeatureAPI;
-+ use OpenFeature\Providers\Flagd\FlagdProvider;
-+ use OpenFeature\Providers\Flagd\config\HttpConfig;
-+ use GuzzleHttp\Client;
-+ use GuzzleHttp\Psr7\HttpFactory;
+// diff-add-block-start
+use OpenFeature\Providers\Flagd\FlagdProvider;
+use OpenFeature\Providers\Flagd\config\HttpConfig;
+use GuzzleHttp\Client;
+use GuzzleHttp\Psr7\HttpFactory;
+// diff-add-block-end
 ```
 
 Finally, we need to register the provider with OpenFeature.
 
-```diff
+```php
 Route::get('/hello', function () {
     $api = OpenFeatureAPI::getInstance();
-+
-+  $httpClient = new Client();
-+  $httpFactory = new HttpFactory();
-+  $api->setProvider(new FlagdProvider([
-+         'httpConfig' => new HttpConfig(
-+              $httpClient,
-+              $httpFactory,
-+              $httpFactory,
-+         )
-+     ]));
+// diff-add-block-start
+
+    $httpClient = new Client();
+    $httpFactory = new HttpFactory();
+    $api->setProvider(new FlagdProvider([
+        'httpConfig' => new HttpConfig(
+            $httpClient,
+            $httpFactory,
+            $httpFactory,
+        )
+    ]));
+// diff-add-block-end
     $client = $api->getClient();
     if($client->getBooleanValue("welcome-message", false)){
         return response()->json(['message' => 'Hello, World! open feature']);

--- a/src/components/custom/tutorial/flagd-change-content.mdx
+++ b/src/components/custom/tutorial/flagd-change-content.mdx
@@ -1,6 +1,6 @@
 Let's change the feature flag in our `flags.flagd.json`, making `defaultVariant` to `on`
 
-```diff
+```json
 {
   "flags": {
     "welcome-message": {
@@ -9,8 +9,10 @@ Let's change the feature flag in our `flags.flagd.json`, making `defaultVariant`
         "off": false
       },
       "state": "ENABLED",
--      "defaultVariant": "off"
-+      "defaultVariant": "on"
+// diff-remove
+      "defaultVariant": "off"
+// diff-add
+      "defaultVariant": "on"
     }
   }
 }


### PR DESCRIPTION
This adds colored diff output to all existing tutorials matching the format used for the Node tutorial. Looks much easier to read and does not interfere with copy-paste.