### PR TITLE
Adding Flagsmith Dotnet Provider

### DIFF
--- a/src/datasets/providers/flagsmith.ts
+++ b/src/datasets/providers/flagsmith.ts
@@ -17,5 +17,11 @@ export const Flagsmith: Provider = {
       href: 'https://github.com/open-feature/java-sdk-contrib/tree/main/providers/flagsmith',
       category: ['Server'],
     },
+    {
+        technology: '.NET',
+        vendorOfficial: true,
+        href: 'https://github.com/open-feature/dotnet-sdk-contrib/tree/main/src/OpenFeature.Contrib.Providers.Flagsmith',
+        category: ['Server'],
+    },
   ],
 };


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
Adding a reference to the Flagsmith .Net Provider to the Openfeature.dev site so that it appears in the ecosystem of providers

### Related Issues

### Notes

### Follow-up Tasks

### How to test

- Run yarn start
- Go to the Ecosystems page
- Filter by Flagsmith to confirm the .Net provider appears