### PR TITLE
chore: disable automerge

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,7 +3,6 @@
   "extends": [
     "config:recommended",
     ":automergeTypes",
-    ":automergeStableNonMajor",
     "npm:unpublishSafe"
   ],
   "semanticCommits": "enabled",


### PR DESCRIPTION
## This PR

- disables automerging

### Notes

A recent minor update to Docusarus broke CSS styling. This was automatically merged by Renovate. Since we don't have visual tests in place, we should disable automerging so we can double-check the preview.

