### PR TITLE
fix: DevCycle Java provider link

### DIFF
--- a/src/datasets/providers/devcycle.ts
+++ b/src/datasets/providers/devcycle.ts
@@ -14,7 +14,7 @@ export const DevCycle: Provider = {
     {
       technology: 'Java',
       vendorOfficial: true,
-      href: 'https://docs.devcycle.com/sdk/server-side-sdks/java-local/java-local-openfeature',
+      href: 'https://docs.devcycle.com/sdk/server-side-sdks/java/java-openfeature',
       category: ['Server'],
     },
     {


### PR DESCRIPTION
## This PR
- Fixed link to DevCycle Java Provider docs


