### PR TITLE
fix: update go tutorial removing deprecated openfeature sdk

### DIFF
--- a/docs/tutorials/getting-started/go.mdx
+++ b/docs/tutorials/getting-started/go.mdx
@@ -63,8 +63,6 @@ func main() {
     // Setup a simple endpoint
     engine.GET("/hello", func(c *gin.Context) {
         c.JSON(http.StatusOK, defaultMessage)
-        return
-
     })
 
     engine.Run()
@@ -111,7 +109,6 @@ func main() {
        engine.GET("/hello", func(c *gin.Context) {
 // diff-remove-block-start
                c.JSON(http.StatusOK, defaultMessage)
-               return
 
 // diff-remove-block-end
 // diff-add-block-start
@@ -131,12 +128,13 @@ func main() {
        })
 
        engine.Run()
+}
 ```
 
 To add OpenFeature SDK dependency to the application, run the following commands.
 
 ```shell
-go get github.com/open-feature/go-sdk/pkg/openfeature
+go get github.com/open-feature/go-sdk/openfeature
 go mod tidy
 ```
 
@@ -164,7 +162,9 @@ import (
        "github.com/gin-gonic/gin"
 // diff-add
        flagd "github.com/open-feature/go-sdk-contrib/providers/flagd/pkg"
-       "github.com/open-feature/go-sdk/pkg/openfeature"
+       "log"
+// diff-add-block-end
+       "github.com/open-feature/go-sdk/openfeature"
        "net/http"
 )
 
@@ -195,11 +195,12 @@ The complete `main.go` file is given below:
 package main
 
 import (
-    "context"
-    "github.com/gin-gonic/gin"
-    flagd "github.com/open-feature/go-sdk-contrib/providers/flagd/pkg"
-    "github.com/open-feature/go-sdk/pkg/openfeature"
-    "net/http"
+	"context"
+	"log"
+	"net/http"
+	"github.com/gin-gonic/gin"
+	flagd "github.com/open-feature/go-sdk-contrib/providers/flagd/pkg"
+	"github.com/open-feature/go-sdk/openfeature"
 )
 
 const defaultMessage = "Hello!"


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

This pull request removes the deprecated go package `github.com/open-feature/go-sdk/pkg/openfeature` and includes minor documentation improvements. The changes include:

- Importing `github.com/open-feature/go-sdk/openfeature` due to `github.com/open-feature/go-sdk/pkg/openfeature` is deprecated from SDK
- Running `go get github.com/open-feature/go-sdk/openfeature` to fetch the SDK.
- Adding missing imports
- Minor go improvements

### Related Issues

### Notes
<!-- any additional notes for this PR -->

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

### How to test
<!-- if applicable, add testing instructions under this section -->

Files Modified

- `openfeature.dev/docs/tutorials/getting-started/go.mdx`

## How to Test

1. Pull down this branch.
2. Compile and run locally
3. Follow the instructions and steps to generate go implementation
