### PR TITLE
Add missing curly brace in golang tutorial

### DIFF
--- a/docs/tutorials/getting-started/go.mdx
+++ b/docs/tutorials/getting-started/go.mdx
@@ -131,6 +131,7 @@ func main() {
        })
 
        engine.Run()
+}
 ```
 
 To add OpenFeature SDK dependency to the application, run the following commands.


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
Updates the golang tutorial by adding a missing curly brace in one of the code blocks

### Notes
Was running through the golang tutorial and found this missing curly-brace 🎉 
