### PR TITLE
Dont use web-based-SDK in node apps.

### DIFF
--- a/docs/reference/technologies/client/web/index.mdx
+++ b/docs/reference/technologies/client/web/index.mdx
@@ -45,6 +45,12 @@ Last updated at Thu May 02 2024 08:07:45 GMT+0000 (Coordinated Universal Time)
 
 ### Install
 
+:::tip
+
+This SDK is designed for running in web browsers. If you are writing a server-side Javascript application in node.js you probably want the [NodeJS SDK](/docs/reference/technologies/server/javascript/).
+
+:::
+
 #### npm
 
 ```sh


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR

Adds a warning for people mistaking the browser JS SDK with the server side node SDK. We had a Flagsmith user getting confused here - seen this a lot with our own SDKs!

### Related Issues

### Notes

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

### How to test
<!-- if applicable, add testing instructions under this section -->

