### PR TITLE
doc: update broken link for youtube channel 

### DIFF
--- a/blog/april-2023-update
+++ b/blog/april-2023-update
@@ -29,7 +29,7 @@ We're transitioning over to the [CNCF Mailing List](https://lists.cncf.io/g/cncf
  
 Chat with us on Slack! Join in and talk to us in the [#openfeature](https://cloud-native.slack.com/archives/C0344AANLA1) channel on [CNCF Slack](http://cloud-native.slack.com/). If you're not a part of the CNCF slack, you can [get an invite here](https://communityinviter.com/apps/cloud-native/cncf).
 
-And don't forget to follow us on all the socials! [Twitter](http://twitter.com/OpenFeature) | [LinkedIn](https://www.linkedin.com/company/openfeature/) | [YouTube](https://www.youtube.com/@openfeature834/)
+And don't forget to follow us on all the socials! [Twitter](http://twitter.com/OpenFeature) | [LinkedIn](https://www.linkedin.com/company/openfeature/) | [YouTube](https://www.youtube.com/@openfeature/)
 
 ## New and Notable
 

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -133,7 +133,7 @@ const themeConfig: ThemeCommonConfig & AlgoliaThemeConfig = {
           },
           {
             label: 'YouTube',
-            href: 'https://www.youtube.com/@openfeature834',
+            href: 'https://www.youtube.com/@openfeature',
           },
         ],
       },


### PR DESCRIPTION
This pull request fixes broken links in the [docusaurus.config.ts](https://github.com/open-feature/openfeature.dev/blob/0b8948b33ad5b0cee8111aaf9fb7cdb582fc3991/docusaurus.config.ts#L136) file and blog entry. The link previously pointed to https://www.youtube.com/@openfeature834, but the URL has changed.

<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

- fix broken link to https://www.youtube.com/@openfeature
