### PR TITLE
doc(technologies.server.java): use proper variable

### DIFF
--- a/docs/reference/technologies/server/java.mdx
+++ b/docs/reference/technologies/server/java.mdx
@@ -282,7 +282,7 @@ OpenFeatureAPI api = OpenFeatureAPI.getInstance();
 Map<String, Value> transactionAttrs = new HashMap<>();
 transactionAttrs.put("userId", new Value("userId"));
 EvaluationContext transactionCtx = new ImmutableContext(transactionAttrs);
-api.setTransactionContext(apiCtx);
+api.setTransactionContext(transactionCtx);
 ```
 Additionally, you can develop a custom transaction context propagator by implementing the `TransactionContextPropagator` interface and registering it as shown above.
 


### PR DESCRIPTION
## This PR
* Fix to use the proper variable

### Related Issues
* NO issue ticket. Directly created the PR, for this super minor fix.

### Notes

### How to test
* Check the fragment code defined to set `transactionContext` -- [Link](https://openfeature.dev/docs/reference/technologies/server/java#transaction-context-propagation) --

```
// adding userId to transaction context
OpenFeatureAPI api = OpenFeatureAPI.getInstance();
Map<String, Value> transactionAttrs = new HashMap<>();
transactionAttrs.put("userId", new Value("userId"));
EvaluationContext transactionCtx = new ImmutableContext(transactionAttrs);
api.setTransactionContext(apiCtx);
```
