### PR TITLE
docs: add missing install command in the Python tutorial

### DIFF
--- a/docs/tutorials/getting-started/python.mdx
+++ b/docs/tutorials/getting-started/python.mdx
@@ -62,6 +62,7 @@ Let's install the OpenFeature SDK using the following commands.
 
 ```sh
 pip install typing-extensions
+pip install openfeature-sdk
 pip install openfeature-provider-flagd
 ```
 


### PR DESCRIPTION
## This PR

- Added missing `openfeature-sdk` install command.
