### PR TITLE
feat(GOFF): Add Ruby provider to the ecosystem page

### DIFF
--- a/src/datasets/providers/goff.ts
+++ b/src/datasets/providers/goff.ts
@@ -6,6 +6,12 @@ export const Goff: Provider = {
   logo: GoffSvg,
   technologies: [
     {
+      technology: 'Ruby',
+      vendorOfficial: true,
+      href: 'https://github.com/open-feature/ruby-sdk-contrib/tree/main/providers/openfeature-go-feature-flag-provider',
+      category: ['Server'],
+    },
+    {
       technology: 'JavaScript',
       vendorOfficial: true,
       href: 'https://github.com/open-feature/js-sdk-contrib/tree/main/libs/providers/go-feature-flag',


### PR DESCRIPTION
## This PR
Waiting for the PR https://github.com/open-feature/ruby-sdk-contrib/pull/38 to be merged and after we can add the provider to the ecosystem page.