### PR TITLE
Add bucket web provider to ecosystem

### DIFF
--- a/src/datasets/providers/bucket.ts
+++ b/src/datasets/providers/bucket.ts
@@ -12,5 +12,11 @@ export const Bucket: Provider = {
       href: 'https://github.com/bucketco/bucket-javascript-sdk/tree/main/packages/openfeature-node-provider',
       category: ['Server'],
     },
+    {
+      technology: 'JavaScript',
+      vendorOfficial: true,
+      href: 'https://github.com/bucketco/bucket-javascript-sdk/tree/main/packages/openfeature-browser-provider',
+      category: ['Client'],
+    },
   ],
 };


### PR DESCRIPTION
## This PR

- adds the Bucket Web Provider to ecosystem pages

### Related Issues

Similar to #674 

### How to test
Tested locally

