### PR TITLE
chore: remove announcement bar

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -92,11 +92,6 @@ const themeConfig: ThemeCommonConfig & AlgoliaThemeConfig = {
       },
     ],
   },
-  announcementBar: {
-    id: 'announcing-angular-sdk',
-    content:
-      'Psst! We\'re excited to kick off the very first OpenFeature Summit. Read more <a href="https://events.linuxfoundation.org/kubecon-cloudnativecon-north-america/co-located-events/openfeature-summit/">here</a>!',
-  },
   footer: {
     style: 'dark',
     links: [


### PR DESCRIPTION
Removing the KubeCon announcement banner.