### PR TITLE
docs: fix comment in README for Hook’s after method

### DIFF
--- a/docs/reference/technologies/server/javascript/index.mdx
+++ b/docs/reference/technologies/server/javascript/index.mdx
@@ -380,7 +380,7 @@ import type { Hook, HookContext, EvaluationDetails, FlagValue } from "@openfeatu
 
 export class MyHook implements Hook {
   after(hookContext: HookContext, evaluationDetails: EvaluationDetails<FlagValue>) {
-    // code that runs when there's an error during a flag evaluation
+    // code that runs after flag values are successfully resolved from the provider
   }
 }
 ```


### PR DESCRIPTION
## This PR

- Fixes incorrect comment in the README for the Hook implementation's `after` method.