### PR TITLE
feat: add DevCycle react provider docs, add React as a technology

### DIFF
--- a/src/datasets/providers/devcycle.ts
+++ b/src/datasets/providers/devcycle.ts
@@ -36,6 +36,12 @@ export const DevCycle: Provider = {
       category: ['Client'],
     },
     {
+      technology: 'React',
+      vendorOfficial: true,
+      href: 'https://docs.devcycle.com/sdk/client-side-sdks/react/react-openfeature',
+      category: ['Client'],
+    },
+    {
       technology: 'PHP',
       vendorOfficial: true,
       href: 'https://docs.devcycle.com/sdk/server-side-sdks/php/php-openfeature',

--- a/src/datasets/sdks/react.ts
+++ b/src/datasets/sdks/react.ts
@@ -9,7 +9,7 @@ export const React: SDK = {
   branch: 'main',
   folder: '/packages/react',
   logoKey: 'react-no-fill.svg',
-  technology: 'JavaScript',
+  technology: 'React',
   href: '/docs/reference/technologies/client/web/react',
   includeInSupportMatrix: false,
 };

--- a/src/datasets/types.ts
+++ b/src/datasets/types.ts
@@ -22,7 +22,8 @@ export type Technology =
   | 'Python'
   | 'Swift'
   | 'Rust'
-  | 'Ruby';
+  | 'Ruby'
+  | 'React';
 
 export type Category = 'Server' | 'Client';
 export type Type = 'Hook' | 'Provider' | 'SDK';


### PR DESCRIPTION
## This PR
- Adds a link to DevCycle's React provider docs
- Adds React as its own technology section.

### Notes
Even though the OpenFeature React SDK uses the same Javascript Web providers for all providers, certain providers may want to provide specific install instructions for React and customize the setup for their providers. For example, at DevCycle we are updating our providers and docs so we can identify when a customer is using the DevCycle provider with the OpenFeature React SDK instead of the OpenFeature Web SDK.

(We will also likely do a similar thing for the NestJS SDK)

