### PR TITLE
chore: update ecosystem page ordering based on count

### DIFF
--- a/src/pages/ecosystem.tsx
+++ b/src/pages/ecosystem.tsx
@@ -131,7 +131,7 @@ export default function Ecosystem() {
                     <span className="font-medium text-content">Technology</span>
                     <RefinementList
                       attribute="technology"
-                      sortBy={['name:asc']}
+                      sortBy={['count:desc']}
                       classNames={{
                         count:
                           'ml-2 px-2 rounded-md bg-gray-50 px-2 py-1 text-xs font-medium text-gray-600 ring-1 ring-inset ring-gray-500/10',
@@ -145,10 +145,7 @@ export default function Ecosystem() {
                     <span className="font-medium text-content">Vendor</span>
                     <RefinementList
                       attribute="vendor"
-                      // Perform a case insensitive sort
-                      sortBy={(a, b) => {
-                        return a.name.localeCompare(b.name);
-                      }}
+                      sortBy={['count:desc']}
                       limit={VENDORS_SHOWN_AS_FACET}
                       classNames={{
                         count:


### PR DESCRIPTION
## This PR
- Updates the sort order of the `Technology` and `Vendor` filters to be based on the count of the number of providers. This could help encourage vendors to increase their number of supported platforms.
- The technology section we could keep by name, but I also think there is a directional signal by seeing there are ~40 Javascript providers and only 3 for Rust.
