### PR TITLE
feat: update how react technology selection is handled

### DIFF
--- a/src/datasets/constants.ts
+++ b/src/datasets/constants.ts
@@ -1,5 +1,5 @@
 // Controls the number of items shown on the ecosystem page.
-export const SEARCH_ITEMS_PER_PAGE = 16;
+export const SEARCH_ITEMS_PER_PAGE = 20;
 
 /**
  * Features map to the anchors found in the features column on the SDK README template.

--- a/src/datasets/hooks/index.ts
+++ b/src/datasets/hooks/index.ts
@@ -13,6 +13,7 @@ export const ECOSYSTEM_HOOKS: EcosystemElement[] = [OpenTelemetry, Validation, D
         type: 'Hook',
         logo: hook.logo,
         href,
+        allTechnologies: [technology],
         technology,
         vendorOfficial,
         category,

--- a/src/datasets/index.ts
+++ b/src/datasets/index.ts
@@ -8,7 +8,7 @@ export const ECOSYSTEM: EcosystemElement[] = [...ECOSYSTEM_SDKS, ...ECOSYSTEM_PR
     // Creates a unique id per item for the search index
     id: `${s.type}/${s.category}/${s.technology}/${s.vendor}/${s.href}`,
     ...s,
-  })
+  }),
 );
 
 export const TECHNOLOGY_COLOR_MAP: Record<Technology, string> = {
@@ -22,6 +22,7 @@ export const TECHNOLOGY_COLOR_MAP: Record<Technology, string> = {
   Swift: 'bg-orange-50 text-orange-600 ring-orange-500/10',
   Rust: 'bg-pink-50 text-pink-600 ring-pink-500/10',
   Ruby: 'bg-red-50 text-red-600 ring-red-500/10',
+  React: 'bg-green-50 text-green-600 ring-green-500/10',
 };
 
 export const TYPE_COLOR_MAP: Record<Type, string> = {

--- a/src/datasets/index.ts
+++ b/src/datasets/index.ts
@@ -22,7 +22,9 @@ export const TECHNOLOGY_COLOR_MAP: Record<Technology, string> = {
   Swift: 'bg-orange-50 text-orange-600 ring-orange-500/10',
   Rust: 'bg-pink-50 text-pink-600 ring-pink-500/10',
   Ruby: 'bg-red-50 text-red-600 ring-red-500/10',
-  React: 'bg-green-50 text-green-600 ring-green-500/10',
+  React: 'bg-teal-50 text-teal-600 ring-teal-500/10',
+  Angular: 'bg-red-50 text-red-600 ring-red-500/10',
+  NestJS: 'bg-pink-50 text-pink-600 ring-pink-500/10',
 };
 
 export const TYPE_COLOR_MAP: Record<Type, string> = {

--- a/src/datasets/providers/devcycle.ts
+++ b/src/datasets/providers/devcycle.ts
@@ -36,7 +36,8 @@ export const DevCycle: Provider = {
       category: ['Client'],
     },
     {
-      technology: ['React', 'JavaScript'],
+      technology: 'React',
+      parentTechnology: 'JavaScript',
       vendorOfficial: true,
       href: 'https://docs.devcycle.com/sdk/client-side-sdks/react/react-openfeature',
       category: ['Client'],

--- a/src/datasets/providers/devcycle.ts
+++ b/src/datasets/providers/devcycle.ts
@@ -43,6 +43,13 @@ export const DevCycle: Provider = {
       category: ['Client'],
     },
     {
+      technology: 'Angular',
+      parentTechnology: 'JavaScript',
+      vendorOfficial: true,
+      href: 'https://docs.devcycle.com/sdk/client-side-sdks/angular/angular-install',
+      category: ['Client'],
+    },
+    {
       technology: 'PHP',
       vendorOfficial: true,
       href: 'https://docs.devcycle.com/sdk/server-side-sdks/php/php-openfeature',

--- a/src/datasets/providers/devcycle.ts
+++ b/src/datasets/providers/devcycle.ts
@@ -36,7 +36,7 @@ export const DevCycle: Provider = {
       category: ['Client'],
     },
     {
-      technology: 'React',
+      technology: ['React', 'JavaScript'],
       vendorOfficial: true,
       href: 'https://docs.devcycle.com/sdk/client-side-sdks/react/react-openfeature',
       category: ['Client'],

--- a/src/datasets/providers/goff.ts
+++ b/src/datasets/providers/goff.ts
@@ -18,7 +18,7 @@ export const Goff: Provider = {
       category: ['Server'],
     },
     {
-      technology: 'JavaScript',
+      technology: ['JavaScript', 'React'],
       vendorOfficial: true,
       href: 'https://github.com/open-feature/js-sdk-contrib/tree/main/libs/providers/go-feature-flag-web',
       category: ['Client'],

--- a/src/datasets/providers/goff.ts
+++ b/src/datasets/providers/goff.ts
@@ -18,8 +18,7 @@ export const Goff: Provider = {
       category: ['Server'],
     },
     {
-      technology: 'React',
-      parentTechnology: 'JavaScript',
+      technology: 'JavaScript',
       vendorOfficial: true,
       href: 'https://github.com/open-feature/js-sdk-contrib/tree/main/libs/providers/go-feature-flag-web',
       category: ['Client'],

--- a/src/datasets/providers/goff.ts
+++ b/src/datasets/providers/goff.ts
@@ -18,7 +18,8 @@ export const Goff: Provider = {
       category: ['Server'],
     },
     {
-      technology: ['JavaScript', 'React'],
+      technology: 'React',
+      parentTechnology: 'JavaScript',
       vendorOfficial: true,
       href: 'https://github.com/open-feature/js-sdk-contrib/tree/main/libs/providers/go-feature-flag-web',
       category: ['Client'],

--- a/src/datasets/providers/index.ts
+++ b/src/datasets/providers/index.ts
@@ -1,5 +1,5 @@
 import type { ComponentType, SVGProps } from 'react';
-
+import { Category, EcosystemElement, Technology } from '../types';
 import { Bucket } from './bucket';
 import { CloudBees } from './cloudbees';
 import { ConfigCat } from './configcat';
@@ -19,13 +19,21 @@ import { Statsig } from './statsig';
 import { FeatBit } from './featbit';
 import { UserDefaults } from './user-defaults';
 import { GrowthBook } from './growthbook';
-import { Category, EcosystemElement, Technology } from '../types';
 import { MultiProvider } from './multi-provider';
 import { Hypertune } from './hypertune';
 import { Confidence } from './confidence';
 import { ConfigBee } from './configbee';
 import { Tggl } from './tggl';
 import { OFREP } from './ofrep';
+import { SDKS } from '../sdks';
+
+const jsClientChildTechnologies = SDKS.filter(
+  (sdk) => sdk.category === 'Client' && sdk.parentTechnology === 'JavaScript',
+).map((sdk) => sdk.technology);
+
+const jsServerChildTechnologies = SDKS.filter(
+  (sdk) => sdk.category === 'Server' && sdk.parentTechnology === 'JavaScript',
+).map((sdk) => sdk.technology);
 
 export const PROVIDERS: Provider[] = [
   Bucket,
@@ -60,13 +68,16 @@ export const ECOSYSTEM_PROVIDERS: EcosystemElement[] = PROVIDERS.map((provider) 
     ({ category, href, technology, parentTechnology, vendorOfficial }): EcosystemElement => {
       const allTechnologies = [technology, parentTechnology].filter(Boolean);
       if (technology === 'JavaScript' && category[0] === 'Client') {
-        allTechnologies.push('React');
+        allTechnologies.push(...jsClientChildTechnologies);
+      }
+      if (technology === 'JavaScript' && category[0] === 'Server') {
+        allTechnologies.push(...jsServerChildTechnologies);
       }
 
       return {
         vendor: provider.name,
         title:
-          technology === 'JavaScript'
+          technology === 'JavaScript' || parentTechnology === 'JavaScript'
             ? `${provider.name} ${technology} ${category[0] === 'Client' ? 'Web' : 'Node.js'} Provider`
             : `${provider.name} ${technology} ${category} Provider`,
         description: !provider.description

--- a/src/datasets/providers/index.ts
+++ b/src/datasets/providers/index.ts
@@ -57,12 +57,13 @@ export const PROVIDERS: Provider[] = [
 
 export const ECOSYSTEM_PROVIDERS: EcosystemElement[] = PROVIDERS.map((provider) => {
   return provider.technologies.map(({ category, href, technology, vendorOfficial }): EcosystemElement => {
+    const technologyString = Array.isArray(technology) ? technology[0] : technology;
     return {
       vendor: provider.name,
       title:
-        technology === 'JavaScript'
-          ? `${provider.name} ${technology} ${category[0] === 'Client' ? 'Web' : 'Node.js'} Provider`
-          : `${provider.name} ${technology} ${category} Provider`,
+        technologyString === 'JavaScript'
+          ? `${provider.name} ${technologyString} ${category[0] === 'Client' ? 'Web' : 'Node.js'} Provider`
+          : `${provider.name} ${technologyString} ${category} Provider`,
       description: !provider.description
         ? createDefaultDescription(provider.name, vendorOfficial)
         : typeof provider.description === 'string'
@@ -87,7 +88,12 @@ function createDefaultDescription(vendor: string, official: boolean): string {
 export type Provider = {
   name: string;
   logo: ComponentType<SVGProps<SVGSVGElement>>;
-  technologies: Array<{ technology: Technology; vendorOfficial: boolean; href: string; category: Category[] }>;
+  technologies: Array<{
+    technology: Technology | Technology[];
+    vendorOfficial: boolean;
+    href: string;
+    category: Category[];
+  }>;
   description?: string | ((vendorSupported: boolean) => string);
   excludeFromLandingPage?: boolean;
 };

--- a/src/datasets/providers/index.ts
+++ b/src/datasets/providers/index.ts
@@ -56,27 +56,35 @@ export const PROVIDERS: Provider[] = [
 ];
 
 export const ECOSYSTEM_PROVIDERS: EcosystemElement[] = PROVIDERS.map((provider) => {
-  return provider.technologies.map(({ category, href, technology, vendorOfficial }): EcosystemElement => {
-    const technologyString = Array.isArray(technology) ? technology[0] : technology;
-    return {
-      vendor: provider.name,
-      title:
-        technologyString === 'JavaScript'
-          ? `${provider.name} ${technologyString} ${category[0] === 'Client' ? 'Web' : 'Node.js'} Provider`
-          : `${provider.name} ${technologyString} ${category} Provider`,
-      description: !provider.description
-        ? createDefaultDescription(provider.name, vendorOfficial)
-        : typeof provider.description === 'string'
-          ? provider.description
-          : provider.description(vendorOfficial),
-      type: 'Provider',
-      logo: provider.logo,
-      href,
-      technology,
-      vendorOfficial,
-      category,
-    };
-  });
+  return provider.technologies.map(
+    ({ category, href, technology, parentTechnology, vendorOfficial }): EcosystemElement => {
+      const allTechnologies = [technology, parentTechnology].filter(Boolean);
+      if (technology === 'JavaScript' && category[0] === 'Client') {
+        allTechnologies.push('React');
+      }
+
+      return {
+        vendor: provider.name,
+        title:
+          technology === 'JavaScript'
+            ? `${provider.name} ${technology} ${category[0] === 'Client' ? 'Web' : 'Node.js'} Provider`
+            : `${provider.name} ${technology} ${category} Provider`,
+        description: !provider.description
+          ? createDefaultDescription(provider.name, vendorOfficial)
+          : typeof provider.description === 'string'
+            ? provider.description
+            : provider.description(vendorOfficial),
+        type: 'Provider',
+        logo: provider.logo,
+        href,
+        allTechnologies,
+        technology,
+        parentTechnology,
+        vendorOfficial,
+        category,
+      };
+    },
+  );
 }).flat();
 
 function createDefaultDescription(vendor: string, official: boolean): string {
@@ -89,7 +97,8 @@ export type Provider = {
   name: string;
   logo: ComponentType<SVGProps<SVGSVGElement>>;
   technologies: Array<{
-    technology: Technology | Technology[];
+    technology: Technology;
+    parentTechnology?: Technology;
     vendorOfficial: boolean;
     href: string;
     category: Category[];

--- a/src/datasets/sdks/angular.ts
+++ b/src/datasets/sdks/angular.ts
@@ -9,7 +9,8 @@ export const Angular: SDK = {
   branch: 'main',
   folder: '/packages/angular/projects/angular-sdk',
   logoKey: 'angular-no-fill.svg',
-  technology: 'JavaScript',
+  technology: 'Angular',
+  parentTechnology: 'JavaScript',
   href: '/docs/reference/technologies/client/web/angular',
   includeInSupportMatrix: false,
 };

--- a/src/datasets/sdks/ecosystem.ts
+++ b/src/datasets/sdks/ecosystem.ts
@@ -44,7 +44,9 @@ export const ECOSYSTEM_SDKS: EcosystemElement[] = SDKS.map((sdk) => {
     category: [sdk.category],
     href: sdk.href,
     logo: logo,
+    allTechnologies: [sdk.technology, sdk.parentTechnology].filter(Boolean),
     technology: sdk.technology,
+    parentTechnology: sdk.parentTechnology,
     type: 'SDK',
     vendorOfficial: false,
   };

--- a/src/datasets/sdks/index.ts
+++ b/src/datasets/sdks/index.ts
@@ -68,7 +68,9 @@ export type SDK = {
   /**
    * Friendly name of the technology of the SDK.
    */
-  technology: Technology | Technology[];
+  technology: Technology;
+
+  parentTechnology?: Technology;
   /**
    * Link to the SDK documentation
    */

--- a/src/datasets/sdks/index.ts
+++ b/src/datasets/sdks/index.ts
@@ -68,7 +68,7 @@ export type SDK = {
   /**
    * Friendly name of the technology of the SDK.
    */
-  technology: Technology;
+  technology: Technology | Technology[];
   /**
    * Link to the SDK documentation
    */

--- a/src/datasets/sdks/index.ts
+++ b/src/datasets/sdks/index.ts
@@ -69,7 +69,9 @@ export type SDK = {
    * Friendly name of the technology of the SDK.
    */
   technology: Technology;
-
+  /**
+   * The parent technology of the SDK. For example, JavaScript is the parent technology of React and Angular.
+   */
   parentTechnology?: Technology;
   /**
    * Link to the SDK documentation

--- a/src/datasets/sdks/nestjs.ts
+++ b/src/datasets/sdks/nestjs.ts
@@ -9,7 +9,8 @@ export const Nestjs: SDK = {
   branch: 'main',
   folder: '/packages/nest',
   logoKey: 'nestjs-no-fill.svg',
-  technology: 'JavaScript',
+  technology: 'NestJS',
+  parentTechnology: 'JavaScript',
   href: '/docs/reference/technologies/server/javascript/nestjs',
   includeInSupportMatrix: false,
 };

--- a/src/datasets/sdks/react.ts
+++ b/src/datasets/sdks/react.ts
@@ -9,7 +9,7 @@ export const React: SDK = {
   branch: 'main',
   folder: '/packages/react',
   logoKey: 'react-no-fill.svg',
-  technology: 'React',
+  technology: ['React', 'JavaScript'],
   href: '/docs/reference/technologies/client/web/react',
   includeInSupportMatrix: false,
 };

--- a/src/datasets/sdks/react.ts
+++ b/src/datasets/sdks/react.ts
@@ -9,7 +9,8 @@ export const React: SDK = {
   branch: 'main',
   folder: '/packages/react',
   logoKey: 'react-no-fill.svg',
-  technology: ['React', 'JavaScript'],
+  technology: 'React',
+  parentTechnology: 'JavaScript',
   href: '/docs/reference/technologies/client/web/react',
   includeInSupportMatrix: false,
 };

--- a/src/datasets/types.ts
+++ b/src/datasets/types.ts
@@ -26,7 +26,9 @@ export type Technology =
   | 'Swift'
   | 'Rust'
   | 'Ruby'
-  | 'React';
+  | 'React'
+  | 'Angular'
+  | 'NestJS';
 
 export type Category = 'Server' | 'Client';
 export type Type = 'Hook' | 'Provider' | 'SDK';

--- a/src/datasets/types.ts
+++ b/src/datasets/types.ts
@@ -6,7 +6,9 @@ export type EcosystemElement = {
   logo: ComponentType<SVGProps<SVGSVGElement>>;
   title: string;
   description: string;
-  technology: Technology | Technology[];
+  allTechnologies: Technology[];
+  technology: Technology;
+  parentTechnology?: Technology;
   type: Type;
   vendorOfficial: boolean;
   category: Category[];

--- a/src/datasets/types.ts
+++ b/src/datasets/types.ts
@@ -6,12 +6,13 @@ export type EcosystemElement = {
   logo: ComponentType<SVGProps<SVGSVGElement>>;
   title: string;
   description: string;
-  technology: Technology;
+  technology: Technology | Technology[];
   type: Type;
   vendorOfficial: boolean;
   category: Category[];
 };
 
+// TODO: should this just be a list of technolgies from the SDKs?
 export type Technology =
   | 'JavaScript'
   | 'Java'

--- a/src/pages/ecosystem.tsx
+++ b/src/pages/ecosystem.tsx
@@ -13,11 +13,12 @@ import NoResultsBoundary from '../partials/ecosystem/no-results-boundary';
 import PageIllustration from '../partials/page-illustration';
 import Hit from '../partials/ecosystem/hit';
 import ScrollTo from '../partials/ecosystem/scroll-to';
+import { ItemsJsOptions } from 'instantsearch-itemsjs-adapter/lib/itemsjsInterface';
 
 const VENDORS_SHOWN_AS_FACET = 20;
 const TECHNOLOGIES_SHOWN_AS_FACET = 12;
 
-const options = {
+const options: ItemsJsOptions = {
   searchableFields: ['title', 'description'],
   query: '',
   aggregations: {
@@ -32,8 +33,9 @@ const options = {
       size: 2,
       conjunction: true,
     },
-    technology: {
+    allTechnologies: {
       title: 'technologies',
+      // searchInField: ['technology', 'parentTechnology'],
       size: TECHNOLOGIES_SHOWN_AS_FACET,
       hide_zero_doc_count: true,
       conjunction: false,
@@ -49,8 +51,7 @@ const options = {
       size: 2,
       conjunction: true,
     },
-  },
-  removeStopWordFilter: false,
+  }
 };
 
 const index = createIndex(ECOSYSTEM, options);
@@ -131,7 +132,7 @@ export default function Ecosystem() {
                   <div className="border-0 border-solid border-t border-gray-200 py-4">
                     <span className="font-medium text-content">Technology</span>
                     <RefinementList
-                      attribute="technology"
+                      attribute="allTechnologies"
                       sortBy={['count:desc']}
                       limit={TECHNOLOGIES_SHOWN_AS_FACET}
                       classNames={{

--- a/src/pages/ecosystem.tsx
+++ b/src/pages/ecosystem.tsx
@@ -16,7 +16,7 @@ import ScrollTo from '../partials/ecosystem/scroll-to';
 import { ItemsJsOptions } from 'instantsearch-itemsjs-adapter/lib/itemsjsInterface';
 
 const VENDORS_SHOWN_AS_FACET = 20;
-const TECHNOLOGIES_SHOWN_AS_FACET = 12;
+const TECHNOLOGIES_SHOWN_AS_FACET = 15;
 
 const options: ItemsJsOptions = {
   searchableFields: ['title', 'description'],
@@ -51,7 +51,8 @@ const options: ItemsJsOptions = {
       size: 2,
       conjunction: true,
     },
-  }
+  },
+  removeStopWordFilter: false,
 };
 
 const index = createIndex(ECOSYSTEM, options);

--- a/src/pages/ecosystem.tsx
+++ b/src/pages/ecosystem.tsx
@@ -66,7 +66,7 @@ export default function Ecosystem() {
         routing={true}
         future={{ preserveSharedStateOnUnmount: true }}
       >
-        <Configure hitsPerPage={SEARCH_ITEMS_PER_PAGE}></Configure>
+        <Configure hitsPerPage={SEARCH_ITEMS_PER_PAGE} />
         <ScrollTo>
           <div className="flex flex-col min-h-screen overflow-hidden">
             <main className="grow">

--- a/src/pages/ecosystem.tsx
+++ b/src/pages/ecosystem.tsx
@@ -15,6 +15,7 @@ import Hit from '../partials/ecosystem/hit';
 import ScrollTo from '../partials/ecosystem/scroll-to';
 
 const VENDORS_SHOWN_AS_FACET = 20;
+const TECHNOLOGIES_SHOWN_AS_FACET = 12;
 
 const options = {
   searchableFields: ['title', 'description'],
@@ -33,7 +34,7 @@ const options = {
     },
     technology: {
       title: 'technologies',
-      size: 12,
+      size: TECHNOLOGIES_SHOWN_AS_FACET,
       hide_zero_doc_count: true,
       conjunction: false,
     },
@@ -132,6 +133,7 @@ export default function Ecosystem() {
                     <RefinementList
                       attribute="technology"
                       sortBy={['count:desc']}
+                      limit={TECHNOLOGIES_SHOWN_AS_FACET}
                       classNames={{
                         count:
                           'ml-2 px-2 rounded-md bg-gray-50 px-2 py-1 text-xs font-medium text-gray-600 ring-1 ring-inset ring-gray-500/10',

--- a/src/partials/ecosystem/hit.tsx
+++ b/src/partials/ecosystem/hit.tsx
@@ -25,7 +25,17 @@ export default function Hit({ hit }: { hit: EcosystemElement }) {
       <h3>{hit.title}</h3>
       <p className="h-20 leading-snug line-clamp-3">{hit.description}</p>
       <div className="flex gap-2 flex-wrap mt-auto">
-        <Pill color={TECHNOLOGY_COLOR_MAP[hit.technology]}>{hit.technology}</Pill>
+        {/* {Array.isArray(hit.technology) ? (
+          hit.technology.map((tech) => (
+            <Pill key={tech} color={TECHNOLOGY_COLOR_MAP[tech]}>
+              {tech}
+            </Pill>
+          ))
+        ) : ( */}
+          <Pill color={TECHNOLOGY_COLOR_MAP[Array.isArray(hit.technology) ? hit.technology[0] : hit.technology]}>
+            {Array.isArray(hit.technology) ? hit.technology[0] : hit.technology}
+          </Pill>
+        {/* )} */}
         <Pill color={TYPE_COLOR_MAP[hit.type]}>{hit.type}</Pill>
         <Pill>{hit.category}</Pill>
       </div>

--- a/src/partials/ecosystem/hit.tsx
+++ b/src/partials/ecosystem/hit.tsx
@@ -23,14 +23,14 @@ export default function Hit({ hit }: { hit: EcosystemElement }) {
         {external && <FontAwesomeIcon icon={faArrowUpRightFromSquare} className="h-4 w-4 opacity-60" />}
       </div>
       <h3>{hit.title}</h3>
-      <p className="h-20 leading-snug line-clamp-3">{hit.description}</p>
-      <div className="flex gap-2 flex-wrap mt-auto">
+      <p className="leading-snug line-clamp-3">{hit.description}</p>
+      <div className="flex gap-2 flex-wrap-reverse mt-auto pt-4">
         <Pill color={TECHNOLOGY_COLOR_MAP[hit.technology]}>{hit.technology}</Pill>
         {hit.parentTechnology && (
           <Pill color={TECHNOLOGY_COLOR_MAP[hit.parentTechnology]}>{hit.parentTechnology}</Pill>
         )}
-        <Pill color={TYPE_COLOR_MAP[hit.type]}>{hit.type}</Pill>
         <Pill>{hit.category}</Pill>
+        <Pill color={TYPE_COLOR_MAP[hit.type]}>{hit.type}</Pill>
       </div>
     </Link>
   );

--- a/src/partials/ecosystem/hit.tsx
+++ b/src/partials/ecosystem/hit.tsx
@@ -25,17 +25,9 @@ export default function Hit({ hit }: { hit: EcosystemElement }) {
       <h3>{hit.title}</h3>
       <p className="h-20 leading-snug line-clamp-3">{hit.description}</p>
       <div className="flex gap-2 flex-wrap mt-auto">
-        {/* {Array.isArray(hit.technology) ? (
-          hit.technology.map((tech) => (
-            <Pill key={tech} color={TECHNOLOGY_COLOR_MAP[tech]}>
-              {tech}
-            </Pill>
-          ))
-        ) : ( */}
-          <Pill color={TECHNOLOGY_COLOR_MAP[Array.isArray(hit.technology) ? hit.technology[0] : hit.technology]}>
-            {Array.isArray(hit.technology) ? hit.technology[0] : hit.technology}
-          </Pill>
-        {/* )} */}
+        <Pill color={TECHNOLOGY_COLOR_MAP[hit.technology]}>
+          {hit.technology}
+        </Pill>
         <Pill color={TYPE_COLOR_MAP[hit.type]}>{hit.type}</Pill>
         <Pill>{hit.category}</Pill>
       </div>

--- a/src/partials/ecosystem/hit.tsx
+++ b/src/partials/ecosystem/hit.tsx
@@ -25,9 +25,10 @@ export default function Hit({ hit }: { hit: EcosystemElement }) {
       <h3>{hit.title}</h3>
       <p className="h-20 leading-snug line-clamp-3">{hit.description}</p>
       <div className="flex gap-2 flex-wrap mt-auto">
-        <Pill color={TECHNOLOGY_COLOR_MAP[hit.technology]}>
-          {hit.technology}
-        </Pill>
+        <Pill color={TECHNOLOGY_COLOR_MAP[hit.technology]}>{hit.technology}</Pill>
+        {hit.parentTechnology && (
+          <Pill color={TECHNOLOGY_COLOR_MAP[hit.parentTechnology]}>{hit.parentTechnology}</Pill>
+        )}
         <Pill color={TYPE_COLOR_MAP[hit.type]}>{hit.type}</Pill>
         <Pill>{hit.category}</Pill>
       </div>


### PR DESCRIPTION
## This PR

- Updates the `Technology` section to have child technology SDKs like `React`, `Angular`, `NestJS` show in the Technology list.
  - When a child technology like `React` is selected, it will show the React SDK, all providers from a vendor marked as their `React` provider (and exclude their base Web provider), and all other vendors' web providers.
  - For Vendors to add specific docs for a child technology Provider like `React` they just need to set their `technology` and `parentTechnology` as so: 

```
{
      ...
      technology: 'React',
      parentTechnology: 'JavaScript',
}
```
- These updates are mostly handled through adding an `allTechnologies` field that lists the multiple technologies a provider should be filterable for. It does not add multiple records to the search hits.
- Updated the number of search hits visible on the page to 20 as the number of providers has grown.

<img width="1501" alt="image" src="https://github.com/user-attachments/assets/e75e4389-a1e4-46df-a980-6e9df7e3dbca" />



