### PR TITLE
Tracking docs update

### DIFF
--- a/docs/reference/concepts/02-provider.mdx
+++ b/docs/reference/concepts/02-provider.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 1
+sidebar_position: 2
 id: provider
 ---
 

--- a/docs/reference/concepts/03-evaluation-context.mdx
+++ b/docs/reference/concepts/03-evaluation-context.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 1
+sidebar_position: 3
 id: evaluation-context
 ---
 

--- a/docs/reference/concepts/04-hooks.mdx
+++ b/docs/reference/concepts/04-hooks.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 1
+sidebar_position: 4
 id: hooks
 ---
 

--- a/docs/reference/concepts/05-events.mdx
+++ b/docs/reference/concepts/05-events.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 1
+sidebar_position: 5
 id: events
 ---
 

--- a/docs/reference/concepts/06-sdk-paradigms.mdx
+++ b/docs/reference/concepts/06-sdk-paradigms.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 1
+sidebar_position: 6
 id: sdk-paradigms
 ---
 

--- a/docs/reference/concepts/07-tracking.mdx
+++ b/docs/reference/concepts/07-tracking.mdx
@@ -5,10 +5,18 @@ id: tracking
 
 # Tracking
 
+import Tabs from '@theme/Tabs';
+import TabItem from '@theme/TabItem';
+
+Tracking, as it relates to an OpenFeature provider, is the concept of associating a metric or KPI with the evaluation context of a feature flag. 
+This association can be relevant to the measurement of changes to application performance, whether in the context of business KPIs or system performance. 
+Tracking functionality is primarily important to the process of experimentation.
+
+
 ## Experimentation, in Brief
 
-_Tracking_ functionality is essential for measuring outcomes and conducting robust experimentation with feature flags.
-It "closes the gap" between flag evaluations and user actions, such as page visits.
+Tracking functionality is essential for measuring outcomes and conducting robust experimentation with feature flags.
+It "closes the gap" between flag evaluations and key KPIs such as conversions or time spent.
 For example, a feature flag controlling the order of items in a menu may lead to increased usage of items earlier in the list.
 Such a flag can be associated with `track` events emitted when a menu item is clicked.
 Finally, since the contextual information of the flag evaluation and track event contain common properties (such as user identifiers), metrics can be derived to validate this assumption.
@@ -27,3 +35,27 @@ sequenceDiagram
   Tracking Hook->>-Evaluation API: evaluate
   Evaluation API->>Analytics Platform: track
 ```
+
+## Track Event
+When using the `track` function with your OpenFeature provider the only required field is a label. 
+You will not need to pass in an identifier or the context of the flags that are being evaluated, given the OpenFeature provider already holds this context. 
+
+If desired, or if your feature flagging tool of choice supports it, you can optionally associate a map of additional metadata with each track event.
+
+
+<Tabs groupId="code">
+<TabItem value="js" label="TypeScript">
+
+```ts
+// flag is evaluated
+client.getBooleanValue('new-feature', false);
+
+// anywhere else in your application a relevant KPI can be tracked
+client.track('conversion-tracked');
+
+// optionally additional data can be associated with the event
+client.track('conversion-tracked', {"value":99.77, "currencyCode":"USD"});
+```
+
+</TabItem>
+</Tabs>

--- a/docs/reference/concepts/07-tracking.mdx
+++ b/docs/reference/concepts/07-tracking.mdx
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 1
+sidebar_position: 7
 id: tracking
 ---
 
@@ -8,22 +8,31 @@ id: tracking
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-Tracking, as it relates to an OpenFeature provider, is the concept of associating a metric or KPI with the evaluation context of a feature flag. 
-This association can be relevant to the measurement of changes to application performance, whether in the context of business KPIs or system performance. 
-Tracking functionality is primarily important to the process of experimentation.
+Tracking in OpenFeature is the process of associating metrics or KPIs with feature flag evaluation contexts. 
+This association helps measure the impact of feature changes on both business KPIs and system performance, making it particularly valuable for experimentation.
 
 
-## Experimentation, in Brief
+## Use Cases
 
-Tracking functionality is essential for measuring outcomes and conducting robust experimentation with feature flags.
-It "closes the gap" between flag evaluations and key KPIs such as conversions or time spent.
-For example, a feature flag controlling the order of items in a menu may lead to increased usage of items earlier in the list.
-Such a flag can be associated with `track` events emitted when a menu item is clicked.
-Finally, since the contextual information of the flag evaluation and track event contain common properties (such as user identifiers), metrics can be derived to validate this assumption.
+Tracking events associated with flag evaluations serves two primary purposes:
+
+### Performance Monitoring
+
+When changes are made to an application via feature flags, tracking helps measure their impact on performance. By associating events with flag evaluation contexts 
+and sending this data to telemetry or analytics platforms, teams can determine whether specific flag configurations improve or degrade measured performance, 
+whether business metrics or system performance.
+
+### Experimentation
+
+Tracking creates a crucial link between flag evaluations and business outcomes, enabling robust experimentation. Experimentation differs from generalized 
+Performance Monitoring in its execution. The most common form of Experimentation being A/B testing which is when two variations of an application or feature 
+are distributed randomly to similar groups and the differences in metrics is evaluated. For example, if a feature flag controls the order 
+of items in a menu, tracking events can be emitted when users click on menu items. The feature flag provider can typically be set to distribute the different variations 
+equally to your audience, making this an A/B test, helping to validate hypotheses about user behavior in a statistically relevant manner.
 
 ## Providers, Hooks and Integration
 
-In order to accomplish the experimentation above, it's required that the flag provider in use reports events or metrics about the flag evaluations and [tracking calls](/specification/sections/providers/#27-tracking-support) it facilitates.
+In order to accomplish the use cases above, it's required that the flag provider in use reports events or metrics about the flag evaluations and [tracking calls](/specification/sections/providers/#27-tracking-support) it facilitates.
 If your vendor or home-grown solution does not support these functionalities, the OpenFeature SDK offers various integration and extension points to help.
 You can implement your own provider [track](/specification/sections/tracking#61-tracking-api) function (by extending or encapsulating your provider) and use custom [hooks](04-hooks.mdx), to collect and export the appropriate event data to your customer data or analytics platform.
 
@@ -36,26 +45,40 @@ sequenceDiagram
   Evaluation API->>Analytics Platform: track
 ```
 
-## Track Event
-When using the `track` function with your OpenFeature provider the only required field is a label. 
-You will not need to pass in an identifier or the context of the flags that are being evaluated, given the OpenFeature provider already holds this context. 
+## Track Event Implementation
+The `track` function requires only a label parameter. You don’t need to pass an identifier or flag evaluation context since the OpenFeature provider already maintains this information.
 
-If desired, or if your feature flagging tool of choice supports it, you can optionally associate a map of additional metadata with each track event.
-
+Optionally, you can associate additional metadata with each track event if your feature flagging tool supports it.
 
 <Tabs groupId="code">
 <TabItem value="js" label="TypeScript">
 
 ```ts
-// flag is evaluated
-client.getBooleanValue('new-feature', false);
 
-// anywhere else in your application a relevant KPI can be tracked
+// example tracking event recording a conversion
 client.track('conversion-tracked');
 
 // optionally additional data can be associated with the event
-client.track('conversion-tracked', {"value":99.77, "currencyCode":"USD"});
+client.track('conversion-tracked', {
+  "value": 99.77,
+  "currencyCode":"USD"
+});
 ```
 
 </TabItem>
+
+<TabItem value="java" label="Java">
+
+```java
+
+// example tracking event recording a conversion
+client.track("conversion-tracked");
+
+// optionally additional data can be associated with the event
+client.track("conversion-tracked", new TrackingEventDetails(99.77).add("currencyCode", "USD"));
+
+```
+
+</TabItem>
+
 </Tabs>


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
Updates the tracking docs page with more context, use cases and example code.

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Address [DOC] Add event tracking #756


### Notes
- This update also fixes a little bit of the docusaurus sidebar metadata where position was all being set statically to 1

### Follow-up Tasks
N/A

### How to test
N/A

