### PR TITLE
feat: add Sentry python hook to ecosystem page

### DIFF
--- a/src/datasets/hooks/sentry.ts
+++ b/src/datasets/hooks/sentry.ts
@@ -12,5 +12,11 @@ export const Sentry: Hook = {
       href: 'https://docs.sentry.io/platforms/javascript/configuration/integrations/openfeature/',
       category: ['Client'],
     },
+    {
+      technology: 'Python',
+      vendorOfficial: true,
+      href: 'https://docs.sentry.io/platforms/python/configuration/integrations/openfeature/',
+      category: ['Client'],
+    },
   ],
 };


### PR DESCRIPTION
- follow up from this PR which adds the JS Sentry hook: https://github.com/open-feature/openfeature.dev/pull/1043
- Sentry also has a Python hook available, documented here: https://docs.sentry.io/platforms/python/configuration/integrations/openfeature/
- relates to https://github.com/getsentry/team-replay/issues/560
- original thread: https://github.com/getsentry/sentry/discussions/73542#discussioncomment-12502060

<img width="731" alt="SCR-20250317-lvns" src="https://github.com/user-attachments/assets/366dfaec-2e31-41fd-a715-95e41e7ddfc2" />
