### PR TITLE
fix: add truncate tag to vercel blog

### DIFF
--- a/blog/2025-03-20-vercel-flags-sdk.md
+++ b/blog/2025-03-20-vercel-flags-sdk.md
@@ -9,6 +9,7 @@ draft: false
 ---
 
 We are happy to share the news that Vercel's new open-source [Flags SDK](https://flags-sdk.dev/) for Next.js and SvelteKit has shipped with a native [OpenFeature Adapter](https://flags-sdk.dev/docs/api-reference/adapters/openfeature).
+<!--truncate-->
 The Flags SDK is an exciting development for standardizing feature flagging in Next.js and SvelteKit, as it takes an [opinionated approach](https://vercel.com/blog/flags-as-code-in-next-js) to how feature flags should be used:
 - Feature Flags are just functions
 - Feature Flags are only evaluated on the server-side, no client-side flag evaluation is supported to improve performance, avoid layout shifts, and other non-optimal user experiences.

--- a/blog/2025-03-25-sentry-openfeature-integration.md
+++ b/blog/2025-03-25-sentry-openfeature-integration.md
@@ -9,7 +9,7 @@ draft: false
 ---
 
 We're excited to announce that Sentry has released OpenFeature Hooks for [JavaScript](https://docs.sentry.io/platforms/javascript/configuration/integrations/openfeature/) and [Python](https://docs.sentry.io/platforms/python/integrations/openfeature/), enabling developers to track feature flag evaluations directly in their error monitoring and performance tracking.
-
+<!--truncate-->
 ## What is the Sentry OpenFeature Integration?
 
 The Sentry OpenFeature Hook allows Sentry to track feature flag evaluations within your application.


### PR DESCRIPTION
## This PR
- add missing `truncate` tag on vercel blog

