### PR TITLE
feat: adding DevCycle iOS Provider to Ecosystem

### DIFF
--- a/src/datasets/providers/devcycle.ts
+++ b/src/datasets/providers/devcycle.ts
@@ -74,5 +74,11 @@ export const DevCycle: Provider = {
       href: 'https://docs.devcycle.com/sdk/server-side-sdks/ruby/ruby-openfeature',
       category: ['Server'],
     },
+    {
+      technology: 'Swift',
+      vendorOfficial: true,
+      href: 'https://docs.devcycle.com/sdk/client-side-sdks/ios/ios-openfeature',
+      category: ['Client'],
+    },
   ],
 };


### PR DESCRIPTION
## This PR
- Adds DevCycle's iOS Provider to the Ecosystem page.


