### PR TITLE
Fix typo in provider MD

### DIFF
--- a/docs/reference/concepts/02-provider.mdx
+++ b/docs/reference/concepts/02-provider.mdx
@@ -80,7 +80,7 @@ However, the following items should be used in the package name:
 
 An example of what it could look like in NPM: `@openfeature/flagd-provider`
 
-### Domain scopped providers
+### Domain scoped providers
 
 OpenFeature supports multiple providers [domain-scoped](https://openfeature.dev/specification/glossary/#domain) to multiple clients in a single application.
 This allows teams to scope flag evaluation to a particular flag management system, making it easier for developers to mix and match providers based on their needs, all from a unified SDK.


### PR DESCRIPTION
Typo: Scopped -> Scoped

<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

- Fixes a typo in the Provider documentation

