### PR TITLE
fix: OFO demo workaround for nginx change(bug)

### DIFF
--- a/docs/tutorials/open-feature-operator/advanced-topics.md
+++ b/docs/tutorials/open-feature-operator/advanced-topics.md
@@ -93,8 +93,17 @@ kubectl wait --timeout=60s --for condition=Available=True deploy --all -n 'cert-
 
 For our NGINX ingress to work with `kind`, we need to install some additional components:
 
+Download our NGINX controller configuration customization:
+
+```shell
+curl -sfL curl -sfL https://raw.githubusercontent.com/open-feature/openfeature.dev/main/static/samples/nginx-config.yaml > nginx-config.yaml
+```
+
+Install the NGINX controller:
+
 ```shell
 kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/main/deploy/static/provider/kind/deploy.yaml
+kubectl apply -f nginx-config.yaml
 kubectl wait --timeout=60s --for condition=Available=True deploy --all -n 'ingress-nginx'
 ```
 

--- a/static/samples/nginx-config.yaml
+++ b/static/samples/nginx-config.yaml
@@ -1,0 +1,17 @@
+
+# This is a patch which disables the strict validation of path type in Ingress resources
+# Otherwise the dots (.) in our gRPC service names will cause the Ingress to fail validation
+# See: https://github.com/kubernetes/ingress-nginx/issues/11176
+apiVersion: v1
+data:
+  strict-validate-path-type: "false"
+kind: ConfigMap
+metadata:
+  labels:
+    app.kubernetes.io/component: controller
+    app.kubernetes.io/instance: ingress-nginx
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/part-of: ingress-nginx
+    app.kubernetes.io/version: 1.12.3
+  name: ingress-nginx-controller
+  namespace: ingress-nginx


### PR DESCRIPTION
The OFO client-side demo is broken due to a breaking change (bug?) in the NGINX controller. This provides a workaround.

See: https://github.com/kubernetes/ingress-nginx/issues/11176