### PR TITLE
feat(ConfigCat): Add ConfigCat OFREP API to the Ecosystem page

### DIFF
--- a/src/datasets/ofrep-api/configcat.ts
+++ b/src/datasets/ofrep-api/configcat.ts
@@ -1,0 +1,9 @@
+import ConfigCatSvg from '@site/static/img/config-cat-no-fill.svg';
+import { OFREP_API } from '.';
+
+export const ConfigCat: OFREP_API = {
+  name: 'ConfigCat',
+  logo: ConfigCatSvg,
+  href: 'https://configcat.com/docs/sdk-reference/openfeature/overview/#openfeature-remote-evaluation-protocol-ofrep',
+  vendorOfficial: true,
+};

--- a/src/datasets/ofrep-api/index.ts
+++ b/src/datasets/ofrep-api/index.ts
@@ -4,9 +4,10 @@ import { EcosystemElement } from '../types';
 import { Goff } from './goff';
 import { Flipt } from './flipt';
 import { Flagd } from './flagd';
+import { ConfigCat } from './configcat';
 export type OFREPElement = Omit<EcosystemElement, 'allTechnologies' | 'technology' | 'category'>;
 
-export const ECOSYSTEM_OFREP_APIS: OFREPElement[] = [DevCycle, Flipt, Goff, Flagd]
+export const ECOSYSTEM_OFREP_APIS: OFREPElement[] = [DevCycle, Flipt, Goff, Flagd, ConfigCat]
   .map(
     (api): OFREPElement => ({
       vendor: api.name,


### PR DESCRIPTION
## This PR
- Adds ConfigCat's [OFREP API](https://configcat.com/docs/sdk-reference/openfeature/overview/#openfeature-remote-evaluation-protocol-ofrep) to the Ecosystem page

