### PR TITLE
chore: add multi-provider to SDK compatability chart

### DIFF
--- a/src/datasets/constants.ts
+++ b/src/datasets/constants.ts
@@ -18,6 +18,7 @@ export const serverSideFeatures = [
   'Transaction Context Propagation',
   'Shutdown',
   'Extending',
+  'Multi-Provider',
 ];
 
 export const clientSideFeatures = [
@@ -31,4 +32,5 @@ export const clientSideFeatures = [
   'Tracking',
   'Shutdown',
   'Extending',
+  'Multi-Provider',
 ];

--- a/src/datasets/sdks/sdk-compatibility.json
+++ b/src/datasets/sdks/sdk-compatibility.json
@@ -52,6 +52,10 @@
       "Extending": {
         "status": "✅",
         "path": "/docs/reference/technologies/server/java#extending"
+      },
+      "Multi-Provider": {
+        "status": "⚠️",
+        "path": "https://github.com/open-feature/java-sdk-contrib/tree/main/providers/multiprovider"
       }
     }
   },
@@ -108,6 +112,10 @@
       "Extending": {
         "status": "✅",
         "path": "/docs/reference/technologies/server/javascript#extending"
+      },
+      "Multi-Provider": {
+        "status": "✅",
+        "path": "https://github.com/open-feature/js-sdk-contrib/tree/main/libs/providers/multi-provider"
       }
     }
   },
@@ -164,6 +172,10 @@
       "Extending": {
         "status": "✅",
         "path": "/docs/reference/technologies/server/dotnet#extending"
+      },
+      "Multi-Provider": {
+        "status": "⚠️",
+        "path": "/docs/reference/technologies/server/dotnet#multi-provider"
       }
     }
   },
@@ -220,6 +232,10 @@
       "Extending": {
         "status": "✅",
         "path": "/docs/reference/technologies/server/go#extending"
+      },
+      "Multi-Provider": {
+        "status": "⚠️",
+        "path": "https://github.com/open-feature/go-sdk-contrib/tree/main/providers/multi-provider"
       }
     }
   },
@@ -276,6 +292,10 @@
       "Extending": {
         "status": "✅",
         "path": "/docs/reference/technologies/server/python#extending"
+      },
+      "Multi-Provider": {
+        "status": "❌",
+        "path": "/docs/reference/technologies/server/python#multi-provider"
       }
     }
   },
@@ -332,6 +352,10 @@
       "Extending": {
         "status": "✅",
         "path": "/docs/reference/technologies/server/php#extending"
+      },
+      "Multi-Provider": {
+        "status": "❌",
+        "path": "/docs/reference/technologies/server/php#multi-provider"
       }
     }
   },
@@ -384,6 +408,10 @@
       "Extending": {
         "status": "✅",
         "path": "/docs/reference/technologies/client/web#extending"
+      },
+      "Multi-Provider": {
+        "status": "✅",
+        "path": "https://github.com/open-feature/js-sdk-contrib/tree/main/libs/providers/multi-provider-web"
       }
     }
   },
@@ -436,6 +464,10 @@
       "Extending": {
         "status": "⚠️",
         "path": "/docs/reference/technologies/client/kotlin#extending"
+      },
+      "Multi-Provider": {
+        "status": "❌",
+        "path": "/docs/reference/technologies/client/kotlin#multi-provider"
       }
     }
   },
@@ -488,6 +520,10 @@
       "Extending": {
         "status": "✅",
         "path": "/docs/reference/technologies/client/swift#extending"
+      },
+      "Multi-Provider": {
+        "status": "❌",
+        "path": "/docs/reference/technologies/client/swift#multi-provider"
       }
     }
   },
@@ -544,6 +580,10 @@
       "Extending": {
         "status": "⚠️",
         "path": "/docs/reference/technologies/server/ruby#extending"
+      },
+      "Multi-Provider": {
+        "status": "❌",
+        "path": "/docs/reference/technologies/server/ruby#multi-provider"
       }
     }
   },
@@ -600,6 +640,10 @@
       "Extending": {
         "status": "✅",
         "path": "/docs/reference/technologies/server/dart#extending"
+      },
+      "Multi-Provider": {
+        "status": "❌",
+        "path": "/docs/reference/technologies/server/dart#multi-provider"
       }
     }
   },
@@ -656,6 +700,10 @@
       "Extending": {
         "status": "✅",
         "path": "/docs/reference/technologies/server/rust#extending"
+      },
+      "Multi-Provider": {
+        "status": "❌",
+        "path": "/docs/reference/technologies/server/rust#multi-provider"
       }
     }
   }


### PR DESCRIPTION
## This PR
- Adds `Multi-Provider` feature to the SDK Compatability chart
