### PR TITLE
chore: hide spec assets folder

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -335,6 +335,7 @@ const config: Config = {
         },
         rehypePlugins: [rehypeGithubAlerts],
         remarkPlugins: [remarkGfm],
+        exclude: ['assets/**'],
         // ... other options
       },
     ],


### PR DESCRIPTION
## This PR

- hides spec assets from the docs

### Notes

Prevents assets from showing up in the docs.

<img width="384" height="720" alt="image" src="https://github.com/user-attachments/assets/16b9ef74-562c-4b3e-86b3-7dfaa1bc25c7" />
