### PR TITLE
feat: add .NET technology support to MultiProvider

### DIFF
--- a/src/datasets/providers/multi-provider.ts
+++ b/src/datasets/providers/multi-provider.ts
@@ -24,5 +24,11 @@ export const MultiProvider: Provider = {
       href: 'https://github.com/open-feature/java-sdk-contrib/tree/main/providers/multiprovider',
       category: ['Server'],
     },
+    {
+      technology: '.NET',
+      vendorOfficial: false,
+      href: 'https://github.com/open-feature/dotnet-sdk/tree/main/src/OpenFeature.Providers.MultiProvider',
+      category: ['Server'],
+    }
   ],
 };


### PR DESCRIPTION
Signed-off-by: André Silva <2493377+askpt@users.noreply.github.com>

<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

This pull request adds support for a new `.NET` MultiProvider to the list of providers in the `multi-provider.ts` file. The change ensures that users can now see and access the `.NET` MultiProvider option alongside existing providers.

Provider additions:

* Added a new `.NET` MultiProvider entry to the `MultiProvider` list in `src/datasets/providers/multi-provider.ts`, including technology, vendor status, link, and category information.