### PR TITLE
feat: add YouTube video embed to homepage

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -6,10 +6,13 @@ import QuestionBlocks from '../partials/question-blocks';
 import FeaturesZigZag from '../partials/features-zigzag';
 import HeroHome from '../partials/hero-home';
 import PageIllustration from '../partials/page-illustration';
+import VideoEmbed from '../partials/video-embed';
 
 import { useLocation } from '@docusaurus/router';
 import 'aos/dist/aos.css';
 import '../css/style.css';
+
+const WHAT_IS_OPENFEATURE_VIDEO_ID = 'heQ83k15ZE4';
 
 export default function Home(): JSX.Element {
   const location = useLocation();
@@ -42,6 +45,7 @@ export default function Home(): JSX.Element {
           {/*  Page sections */}
           <HeroHome />
           <QuestionBlocks />
+          <VideoEmbed videoId={WHAT_IS_OPENFEATURE_VIDEO_ID} />
           <FeaturesZigZag />
         </main>
       </div>

--- a/src/partials/video-embed.tsx
+++ b/src/partials/video-embed.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+import LiteYouTubeEmbed from 'react-lite-youtube-embed';
+import 'react-lite-youtube-embed/dist/LiteYouTubeEmbed.css';
+
+interface VideoEmbedProps {
+  videoId: string;
+  title?: string;
+}
+
+function VideoEmbed({ videoId, title = "YouTube video player" }: VideoEmbedProps) {
+  return (
+    <section>
+      <div className="max-w-6xl mx-auto px-4 sm:px-6">
+        <div className="py-12 md:py-20 border-t border-gray-800">
+          <div className="max-w-3xl mx-auto">
+            <LiteYouTubeEmbed id={videoId} title={title} poster="maxresdefault" webp />
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+export default VideoEmbed;


### PR DESCRIPTION
I noticed that we had this really nice short video overview, and thought it would be good to add to the homepage.

- Added OpenFeature Fundamentals YouTube video embed to the homepage, positioned between QuestionBlocks and FeaturesZigZag sections.



🤖 Generated with [Claude Code](https://claude.com/claude-code)