### PR TITLE
feat: add-rust-provider-documentation

### DIFF
--- a/src/datasets/providers/flagsmith.ts
+++ b/src/datasets/providers/flagsmith.ts
@@ -41,5 +41,11 @@ export const Flagsmith: Provider = {
       href: 'https://github.com/Flagsmith/flagsmith-openfeature-provider-python',
       category: ['Server'],
     },
+    {
+      technology: 'Rust',
+      vendorOfficial: true,
+      href: 'https://github.com/open-feature/rust-sdk-contrib/tree/main/crates/flagsmith',
+      category: ['Server'],
+    },
   ],
 };


### PR DESCRIPTION
## This PR
Adds Flagsmith rust provider to the ecosystem list

### Related Issues
Dependent on https://github.com/open-feature/rust-sdk-contrib/pull/82
