### PR TITLE
feat: add Java technology support to OFREP provider

### DIFF
--- a/src/datasets/providers/ofrep.ts
+++ b/src/datasets/providers/ofrep.ts
@@ -36,5 +36,11 @@ export const OFREP: Provider = {
       href: 'https://github.com/open-feature/dotnet-sdk-contrib/tree/main/src/OpenFeature.Providers.Ofrep',
       vendorOfficial: true,
     },
+    {
+      technology: 'Java',
+      category: ['Server'],
+      href: 'https://github.com/open-feature/java-sdk-contrib/tree/main/providers/ofrep',
+      vendorOfficial: true,
+    },
   ],
 };


### PR DESCRIPTION
Signed-off-by: André Silva <2493377+askpt@users.noreply.github.com>

<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

This pull request adds support for the OFREP provider in Java to the list of providers in `src/datasets/providers/ofrep.ts`. This update ensures that users can now see Java as an officially supported technology for OFREP.

Provider support update:

* Added a new entry for OFREP Java provider, including technology, category, official vendor status, and repository link in `src/datasets/providers/ofrep.ts`.