### PR TITLE
docs: update OFO tutorial versions

### DIFF
--- a/docs/tutorials/open-feature-operator/advanced-topics.md
+++ b/docs/tutorials/open-feature-operator/advanced-topics.md
@@ -64,7 +64,7 @@ We strongly recommend using `kind` for this demo, but if you already have a K8s 
 Download the cluster definition file, `kind-cluster-advanced-topics.yaml`:
 
 ```shell
-curl -sfL curl -sfL https://raw.githubusercontent.com/open-feature/openfeature.dev/main/static/samples/kind-cluster-advanced-topics.yaml > kind-cluster-advanced-topics.yaml
+curl -sfL https://raw.githubusercontent.com/open-feature/openfeature.dev/main/static/samples/kind-cluster-advanced-topics.yaml > kind-cluster-advanced-topics.yaml
 ```
 
 Then, create our cluster using the `kind-cluster-advanced-topics.yaml` file:
@@ -85,7 +85,7 @@ If your cluster already has cert manager, or you're using another solution for c
 Install cert-manager, and wait for it to be ready:
 
 ```shell
-kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.13.2/cert-manager.yaml && \
+kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.20.2/cert-manager.yaml && \
 kubectl wait --timeout=60s --for condition=Available=True deploy --all -n 'cert-manager'
 ```
 
@@ -96,14 +96,16 @@ For our NGINX ingress to work with `kind`, we need to install some additional co
 Download our NGINX controller configuration customization:
 
 ```shell
-curl -sfL curl -sfL https://raw.githubusercontent.com/open-feature/openfeature.dev/main/static/samples/nginx-config.yaml > nginx-config.yaml
+curl -sfL https://raw.githubusercontent.com/open-feature/openfeature.dev/main/static/samples/nginx-config.yaml > nginx-config.yaml
+curl -sfL https://raw.githubusercontent.com/open-feature/openfeature.dev/main/static/samples/nginx-kind-patch.yaml > nginx-kind-patch.yaml
 ```
 
 Install the NGINX controller:
 
 ```shell
-kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/main/deploy/static/provider/kind/deploy.yaml
+kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/controller-v1.15.1/deploy/static/provider/kind/deploy.yaml
 kubectl apply -f nginx-config.yaml
+kubectl patch deployment ingress-nginx-controller -n ingress-nginx --patch-file nginx-kind-patch.yaml
 kubectl wait --timeout=60s --for condition=Available=True deploy --all -n 'ingress-nginx'
 ```
 
@@ -117,7 +119,7 @@ And finally, let's install the operator itself:
   <summary>Install using manifest</summary>
 
   ```shell
-  kubectl apply -f https://github.com/open-feature/open-feature-operator/releases/download/v0.6.1/release.yaml && \
+  kubectl apply -f https://github.com/open-feature/open-feature-operator/releases/download/v0.9.0/release.yaml && \
   kubectl wait --timeout=60s --for condition=Available=True deploy --all -n 'open-feature-operator-system'
   ```
 
@@ -149,7 +151,7 @@ First, lets see how a centralized flagd can be used to serve flags to an *in-pro
 Download the file defining our demo deployment, service and custom resource (CRs), `in-process-evaluation.yaml`:
 
 ```shell
-curl -sfL curl -sfL https://raw.githubusercontent.com/open-feature/playground/main/config/k8s/in-process-evaluation.yaml > in-process-evaluation.yaml
+curl -sfL https://raw.githubusercontent.com/open-feature/playground/main/config/k8s/in-process-evaluation.yaml > in-process-evaluation.yaml
 ```
 
 Let's take a look at the manifest and try to understand what's happening...
@@ -256,7 +258,7 @@ Now, lets see how a centralized flagd can be used to support client-side evaluat
 Download the file defining our demo deployment, service and custom resource (CRs), `in-process-evaluation.yaml`:
 
 ```shell
-curl -sfL curl -sfL https://raw.githubusercontent.com/open-feature/playground/main/config/k8s/client-side-evaluation.yaml > client-side-evaluation.yaml
+curl -sfL https://raw.githubusercontent.com/open-feature/playground/main/config/k8s/client-side-evaluation.yaml > client-side-evaluation.yaml
 ```
 
 Let's take a look at the manifest...

--- a/docs/tutorials/open-feature-operator/quick-start.md
+++ b/docs/tutorials/open-feature-operator/quick-start.md
@@ -46,7 +46,7 @@ We recommend using `kind` for this demo, but if you already have a K8s cluster, 
 Download the cluster definition file, `kind-cluster-quick-start.yaml`:
 
 ```shell
-curl -sfL curl -sfL https://raw.githubusercontent.com/open-feature/openfeature.dev/main/static/samples/kind-cluster-quick-start.yaml > kind-cluster-quick-start.yaml
+curl -sfL https://raw.githubusercontent.com/open-feature/openfeature.dev/main/static/samples/kind-cluster-quick-start.yaml > kind-cluster-quick-start.yaml
 ```
 
 Then, create our cluster using the `kind-cluster-quick-start.yaml` file:
@@ -65,7 +65,7 @@ If your cluster already has cert manager, or you're using another solution for c
 Install cert-manager, and wait for it to be ready:
 
 ```shell
-kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.13.2/cert-manager.yaml && \
+kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.20.2/cert-manager.yaml && \
 kubectl wait --timeout=60s --for condition=Available=True deploy --all -n 'cert-manager'
 ```
 
@@ -77,7 +77,7 @@ And finally, let's install the operator itself:
   <summary>Install using manifest</summary>
 
   ```shell
-  kubectl apply -f https://github.com/open-feature/open-feature-operator/releases/download/v0.6.0/release.yaml && \
+  kubectl apply -f https://github.com/open-feature/open-feature-operator/releases/download/v0.9.0/release.yaml && \
   kubectl wait --timeout=60s --for condition=Available=True deploy --all -n 'open-feature-operator-system'
   ```
 

--- a/static/samples/nginx-config.yaml
+++ b/static/samples/nginx-config.yaml
@@ -12,6 +12,6 @@ metadata:
     app.kubernetes.io/instance: ingress-nginx
     app.kubernetes.io/name: ingress-nginx
     app.kubernetes.io/part-of: ingress-nginx
-    app.kubernetes.io/version: 1.12.3
+    app.kubernetes.io/version: 1.15.1
   name: ingress-nginx-controller
   namespace: ingress-nginx

--- a/static/samples/nginx-kind-patch.yaml
+++ b/static/samples/nginx-kind-patch.yaml
@@ -1,0 +1,20 @@
+# This patch schedules the NGINX ingress controller on the control-plane node,
+# which is where the kind hostPort mapping is configured.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ingress-nginx-controller
+  namespace: ingress-nginx
+spec:
+  template:
+    spec:
+      nodeSelector:
+        ingress-ready: "true"
+        kubernetes.io/os: linux
+      tolerations:
+        - key: node-role.kubernetes.io/control-plane
+          operator: Equal
+          effect: NoSchedule
+        - key: node-role.kubernetes.io/master
+          operator: Equal
+          effect: NoSchedule


### PR DESCRIPTION
## Summary

Update both OFO tutorials with latest dependency versions. All changes tested end-to-end on kind clusters.

### Quick Start
- Bump OFO manifest install from v0.6.0 to v0.9.0
- Bump cert-manager from v1.13.2 to v1.20.2
- Fix duplicate `curl -sfL` in kind cluster download command

### Advanced Topics
- Bump OFO manifest install from v0.6.1 to v0.9.0
- Bump cert-manager from v1.13.2 to v1.20.2
- Fix duplicate `curl -sfL` in 4 download commands
- Pin NGINX ingress manifest to `controller-v1.15.1` (was `@main`)
- Add `nginx-kind-patch.yaml` to schedule NGINX controller on the control-plane node (upstream manifest no longer includes the `ingress-ready` nodeSelector needed for kind)
- Update `nginx-config.yaml` version label to 1.15.1