### PR TITLE
docs: mark Kotlin Logging as launched, Domains as in-progress

### DIFF
--- a/src/datasets/sdks/sdk-compatibility.json
+++ b/src/datasets/sdks/sdk-compatibility.json
@@ -442,11 +442,11 @@
         "path": "/docs/reference/sdks/client/kotlin#hooks"
       },
       "Logging": {
-        "status": "❌",
+        "status": "⚠️",
         "path": "/docs/reference/sdks/client/kotlin#logging"
       },
       "Domains": {
-        "status": "❌",
+        "status": "⚠️",
         "path": "/docs/reference/sdks/client/kotlin#domains"
       },
       "Eventing": {

--- a/src/datasets/sdks/sdk-compatibility.json
+++ b/src/datasets/sdks/sdk-compatibility.json
@@ -442,7 +442,7 @@
         "path": "/docs/reference/sdks/client/kotlin#hooks"
       },
       "Logging": {
-        "status": "⚠️",
+        "status": "✅",
         "path": "/docs/reference/sdks/client/kotlin#logging"
       },
       "Domains": {


### PR DESCRIPTION
## Summary

Updates Kotlin SDK compatibility table:

- **Logging** ❌ → ✅ — shipped in v0.7.2 via [open-feature/kotlin-sdk#220](https://github.com/open-feature/kotlin-sdk/pull/220), [#221](https://github.com/open-feature/kotlin-sdk/pull/221), [#233](https://github.com/open-feature/kotlin-sdk/pull/233)
- **Domains** ❌ → ⚠️ — in active development

No other SDK entries changed.

Signed-off-by: Tyler Potter <tyler.john.potter@gmail.com>