### PR TITLE
docs: add provider lifecycle guidance

### DIFF
--- a/docs/reference/concepts/01-evaluation-api.mdx
+++ b/docs/reference/concepts/01-evaluation-api.mdx
@@ -42,7 +42,7 @@ OpenFeature.setProvider(new YourProviderOfChoice());
 <TabItem value="java" label="Java">
 
 ```java
-import dev.openfeature.javasdk.OpenFeatureAPI;
+import dev.openfeature.sdk.OpenFeatureAPI;
 
 OpenFeatureAPI api = OpenFeatureAPI.getInstance();
 api.setProvider(new YourProviderOfChoice());
@@ -84,6 +84,11 @@ openfeature.api.set_provider(YourProviderOfChoice())
 
 </TabItem>
 </Tabs>
+
+Some providers need to establish connections, load flag data, or validate configuration before they can resolve flags accurately.
+If your SDK exposes a blocking or awaitable registration method, use it during startup when your application needs to avoid default values while the provider initializes.
+If you register the provider asynchronously, attach event handlers for [`PROVIDER_READY`](./events#provider_ready) and [`PROVIDER_ERROR`](./events#provider_error) so your application can react when initialization succeeds or fails.
+See [Events](./events#event-handlers) for language-specific handler examples.
 
 ## Creating a client
 
@@ -275,15 +280,15 @@ These return the value, as well as additional metadata about the flag evaluation
 
 #### Evaluation Details Structure Fields
 
-| Field                    | Description                                                                                   |
-| ------------------------ | --------------------------------------------------------------------------------------------- |
-| flag key                 | the unique identifier for a feature flag                                                      |
-| value                    | the value returned from a flag evaluation                                                     |
-| reason (optional)        | a string explaining why the flag value was returned                                           |
-| variant (optional)       | the variant associated with the return flag value                                             |
-| flag metadata (optional) | a key-value structure which supports definition of arbitrary properties                       |
+| Field                    | Description                                                                              |
+| ------------------------ | ---------------------------------------------------------------------------------------- |
+| flag key                 | the unique identifier for a feature flag                                                 |
+| value                    | the value returned from a flag evaluation                                                |
+| reason (optional)        | a string explaining why the flag value was returned                                      |
+| variant (optional)       | the variant associated with the return flag value                                        |
+| flag metadata (optional) | a key-value structure which supports definition of arbitrary properties                  |
 | error code (optional)    | an [error code](/specification/types#error-code) that categorizes flag evaluation errors |
-| error message (optional) | a string detailing the error                                                                  |
+| error message (optional) | a string detailing the error                                                             |
 
 <Tabs groupId="code">
 <TabItem value="js" label="TypeScript">
@@ -400,6 +405,42 @@ details = client.get_float_details("floatFlag", 1);
 
 # get details of object evaluation
 details = client.get_object_details("objectFlag", {});
+```
+
+</TabItem>
+</Tabs>
+
+## API Shutdown
+
+The OpenFeature API can shut down all registered providers so they can release connections, background workers, file watchers, or other resources.
+Call this from your application shutdown path after you stop evaluating flags.
+The method name varies by SDK; use the shutdown or close function documented by the SDK you are using.
+
+<Tabs groupId="code">
+<TabItem value="js" label="TypeScript">
+
+```ts
+import { OpenFeature } from '@openfeature/server-sdk';
+
+await OpenFeature.close();
+```
+
+</TabItem>
+<TabItem value="java" label="Java">
+
+```java
+import dev.openfeature.sdk.OpenFeatureAPI;
+
+OpenFeatureAPI.getInstance().shutdown();
+```
+
+</TabItem>
+<TabItem value="python" label="Python">
+
+```python
+from openfeature import api
+
+api.shutdown()
 ```
 
 </TabItem>

--- a/docs/reference/concepts/02-provider.mdx
+++ b/docs/reference/concepts/02-provider.mdx
@@ -171,7 +171,7 @@ public class MyProvider implements FeatureProvider {
     }
 
     @Override
-    public void shutdown() {
+    public void shutdown() throws Exception {
         // Close connections or stop background workers here.
     }
 

--- a/docs/reference/concepts/02-provider.mdx
+++ b/docs/reference/concepts/02-provider.mdx
@@ -117,6 +117,71 @@ const multiProvider = new MultiProvider(
 await OpenFeature.setProviderAndWait(multiProvider);
 ```
 
+### Provider lifecycle
+
+Providers can implement lifecycle methods that the SDK calls when the provider is registered and when the API shuts down.
+Use initialization to open network connections, load remote flag state, validate configuration, or start background workers that are required before evaluations should use the provider.
+Use shutdown to release those same resources during application shutdown.
+The exact method names vary by SDK, but they map to the same lifecycle: initialize when the provider is set, and clean up when the [Evaluation API is shut down](./evaluation-api#api-shutdown).
+When your application needs to wait until initialization completes, use the SDK's waitable provider registration method when available.
+If the provider is registered without waiting, application authors can use [`PROVIDER_READY`](./events#provider_ready) and [`PROVIDER_ERROR`](./events#provider_error) handlers to react to provider startup events.
+
+<Tabs groupId="code">
+<TabItem value="js" label="TypeScript">
+
+```ts
+import { EvaluationContext, Provider } from '@openfeature/server-sdk';
+
+class MyFeatureProvider implements Provider {
+  readonly metadata = {
+    name: 'My Feature Provider',
+  } as const;
+
+  readonly runsOn = 'server';
+
+  async initialize(context?: EvaluationContext): Promise<void> {
+    // Open connections, validate configuration, or preload flag state here.
+  }
+
+  async onClose(): Promise<void> {
+    // Close connections or stop background workers here.
+  }
+
+  // Implement the required resolve*Evaluation methods shown in the provider examples below.
+}
+```
+
+</TabItem>
+<TabItem value="java" label="Java">
+
+```java
+import dev.openfeature.sdk.EvaluationContext;
+import dev.openfeature.sdk.FeatureProvider;
+import dev.openfeature.sdk.Metadata;
+
+public class MyProvider implements FeatureProvider {
+    @Override
+    public Metadata getMetadata() {
+        return () -> "My Provider";
+    }
+
+    @Override
+    public void initialize(EvaluationContext evaluationContext) throws Exception {
+        // Open connections, validate configuration, or preload flag state here.
+    }
+
+    @Override
+    public void shutdown() {
+        // Close connections or stop background workers here.
+    }
+
+    // Implement the required evaluation methods shown in the provider examples below.
+}
+```
+
+</TabItem>
+</Tabs>
+
 ### Examples
 
 #### Dynamic Context Implementations (Server-side SDKs)


### PR DESCRIPTION
## Summary

- Document provider readiness during Evaluation API provider registration, including links to PROVIDER_READY and PROVIDER_ERROR event guidance.
- Add an Evaluation API shutdown section with TypeScript, Java, and Python examples.
- Add provider lifecycle guidance with initialization/shutdown examples for TypeScript and Java.
- Update the Java Evaluation API import to the current dev.openfeature.sdk package used by the Java SDK docs.

Closes #119.

## Testing

- corepack yarn install --immutable
- git diff --check
- corepack yarn markdownlint-cli2 docs/reference/concepts/01-evaluation-api.mdx docs/reference/concepts/02-provider.mdx --no-globs
- corepack yarn prettier --check docs/reference/concepts/01-evaluation-api.mdx docs/reference/concepts/02-provider.mdx

Additional checks attempted:

- git submodule update --init --recursive
- corepack yarn build reaches Docusaurus/Webpack but is blocked in this Windows workspace by an existing parent-directory JSON parse issue: D:\CodexWork\package.json contains a BOM and PostCSS reports Unexpected token '?' while loading CSS modules.
- corepack yarn typecheck is blocked by existing repository issues unrelated to this docs change, including missing ./OpenFeatureTechnologiesPage, missing static image modules, and an existing SearchClient type incompatibility in src/pages/ecosystem.tsx.