### PR TITLE
chore: resolve open dependabot security alerts

### DIFF
--- a/package.json
+++ b/package.json
@@ -163,6 +163,7 @@
     "yaml": "^2.8.3",
     "markdownlint-cli2/js-yaml": ">=4.1.1",
     "@docusaurus/theme-mermaid/mermaid": "^11.15.0",
+    "webpack-dev-server/ws": "^8.20.1",
     "styled-components/postcss": "^8.5.10",
     "webpack": "5.104.1",
     "fast-uri": ">=3.1.2",

--- a/package.json
+++ b/package.json
@@ -163,7 +163,7 @@
     "yaml": "^2.8.3",
     "markdownlint-cli2/js-yaml": ">=4.1.1",
     "@docusaurus/theme-mermaid/mermaid": "^11.15.0",
-    "webpack-dev-server/ws": "^8.20.1",
+    "ws": "^8.20.1",
     "styled-components/postcss": "^8.5.10",
     "webpack": "5.104.1",
     "fast-uri": ">=3.1.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -19103,21 +19103,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ws@npm:^7.3.1":
-  version: 7.5.10
-  resolution: "ws@npm:7.5.10"
-  peerDependencies:
-    bufferutil: ^4.0.1
-    utf-8-validate: ^5.0.2
-  peerDependenciesMeta:
-    bufferutil:
-      optional: true
-    utf-8-validate:
-      optional: true
-  checksum: 10c0/bd7d5f4aaf04fae7960c23dcb6c6375d525e00f795dd20b9385902bd008c40a94d3db3ce97d878acc7573df852056ca546328b27b39f47609f80fb22a0a9b61d
-  languageName: node
-  linkType: hard
-
 "ws@npm:^8.20.1":
   version: 8.21.0
   resolution: "ws@npm:8.21.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -19118,9 +19118,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ws@npm:^8.18.0":
-  version: 8.18.3
-  resolution: "ws@npm:8.18.3"
+"ws@npm:^8.20.1":
+  version: 8.21.0
+  resolution: "ws@npm:8.21.0"
   peerDependencies:
     bufferutil: ^4.0.1
     utf-8-validate: ">=5.0.2"
@@ -19129,7 +19129,7 @@ __metadata:
       optional: true
     utf-8-validate:
       optional: true
-  checksum: 10c0/eac918213de265ef7cb3d4ca348b891a51a520d839aa51cdb8ca93d4fa7ff9f6ccb339ccee89e4075324097f0a55157c89fa3f7147bde9d8d7e90335dc087b53
+  checksum: 10c0/ef4a243476283fc49bc7550966c4af4aa0eef56273837211e700de3b664e08604a760cdddcb5ba43c049140e74ccfec5b0ee0bb439e08c2adf9138902fdde5f9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- Bumped `ws` to `>=8.20.1` via global `ws` resolution to resolve moderate vulnerability (uninitialized memory disclosure, alert #218). Lockfile now resolves to `ws@8.21.0` across all consumers (webpack-dev-server, webpack-bundle-analyzer).

Alert #80 (`tsup`, low, DOM Clobbering) has no patched version available and is left open.