### PR TITLE
docs: add FlagLint to ecosystem integrations

### DIFF
--- a/src/datasets/integrations/flaglint.ts
+++ b/src/datasets/integrations/flaglint.ts
@@ -1,0 +1,17 @@
+import FlagLintSvg from '@site/static/img/flaglint-no-fill.svg';
+import { Integration } from '.';
+
+export const FlagLint: Integration = {
+  name: 'FlagLint',
+  logo: FlagLintSvg,
+  description:
+    'Open-source CLI that audits LaunchDarkly Node.js SDK usage and generates safe OpenFeature migration plans.',
+  technologies: [
+    {
+      technology: 'JavaScript',
+      vendorOfficial: true,
+      href: 'https://github.com/flaglint/flaglint',
+      category: ['Server'],
+    },
+  ],
+};

--- a/src/datasets/integrations/index.ts
+++ b/src/datasets/integrations/index.ts
@@ -1,8 +1,9 @@
 import type { ComponentType, SVGProps } from 'react';
 import { DropwizardOpenfeature } from './dropwizard-openfeature';
+import { FlagLint } from './flaglint';
 import { Category, EcosystemElement, Technology } from '../types';
 
-export const ECOSYSTEM_INTEGRATIONS: EcosystemElement[] = [DropwizardOpenfeature]
+export const ECOSYSTEM_INTEGRATIONS: EcosystemElement[] = [DropwizardOpenfeature, FlagLint]
   .map((integration) => {
     return integration.technologies.map(({ vendorOfficial, technology, href, category }): EcosystemElement => {
       return {

--- a/static/img/flaglint-no-fill.svg
+++ b/static/img/flaglint-no-fill.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">
+  <rect x="8" y="5" width="5" height="88" rx="2" fill="currentColor"/>
+  <path d="M13 8 L75 22 L13 42 Z" fill="currentColor"/>
+  <circle cx="72" cy="68" r="16" fill="none" stroke="currentColor" stroke-width="6"/>
+  <line x1="83" y1="79" x2="94" y2="91" stroke="currentColor" stroke-width="6" stroke-linecap="round"/>
+</svg>


### PR DESCRIPTION
Adds FlagLint to the OpenFeature ecosystem page as a JavaScript server-side Integration.

FlagLint is a free, open-source CLI that helps teams migrate from direct LaunchDarkly Node.js SDK usage to OpenFeature by auditing flag usage, identifying migration risk, and generating safe migration plans.

This is listed as an Integration, not a Provider, SDK, or Hook, because FlagLint does not evaluate flags at runtime. It supports OpenFeature adoption during migration.