### PR TITLE
chore: add the unleash python provider to vendor list

### DIFF
--- a/src/datasets/providers/unleash.ts
+++ b/src/datasets/providers/unleash.ts
@@ -29,5 +29,11 @@ export const Unleash: Provider = {
       href: 'https://github.com/open-feature/dotnet-sdk-contrib/tree/main/src/OpenFeature.Providers.Unleash',
       category: ['Server'],
     },
+    {
+      technology: 'Python',
+      vendorOfficial: false,
+      href: 'https://github.com/open-feature/python-sdk-contrib/tree/main/providers/openfeature-provider-unleash',
+      category: ['Server'],
+    },
   ],
 };


### PR DESCRIPTION
Adds a pre-existing unlisted python server provider for Unleash to the Unleash vendor provider dataset

