### PR TITLE
feat: add Switchbox provider

### DIFF
--- a/src/datasets/providers/index.ts
+++ b/src/datasets/providers/index.ts
@@ -23,6 +23,7 @@ import { PostHog } from './posthog';
 import { Prefab } from './prefab';
 import { Reflag } from './reflag';
 import { Split } from './split';
+import { Switchbox } from './switchbox';
 import { Unleash } from './unleash';
 import { Statsig } from './statsig';
 import { FeatBit } from './featbit';
@@ -82,6 +83,7 @@ export const PROVIDERS: Provider[] = [
   Reflag,
   Split,
   Statsig,
+  Switchbox,
   Unleash,
   UserDefaults,
   Vercel,

--- a/src/datasets/providers/switchbox.ts
+++ b/src/datasets/providers/switchbox.ts
@@ -1,0 +1,28 @@
+import SwitchboxSvg from '@site/static/img/switchbox-no-fill.svg';
+import { Provider } from '.';
+
+export const Switchbox: Provider = {
+  name: 'Switchbox',
+  logo: SwitchboxSvg,
+  technologies: [
+    {
+      technology: 'JavaScript',
+      vendorOfficial: true,
+      href: 'https://github.com/ignat14/switchbox-sdk-js/tree/main/packages/openfeature',
+      category: ['Client'],
+    },
+    {
+      technology: 'React',
+      parentTechnology: 'JavaScript',
+      vendorOfficial: true,
+      href: 'https://switchbox.dev/docs/sdk/openfeature',
+      category: ['Client'],
+    },
+    {
+      technology: 'Python',
+      vendorOfficial: true,
+      href: 'https://github.com/ignat14/switchbox-sdk-python/tree/main/providers/openfeature',
+      category: ['Server'],
+    },
+  ],
+};

--- a/static/img/switchbox-no-fill.svg
+++ b/static/img/switchbox-no-fill.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+  <!-- Switchbox toggle mark, colorless per the catalog convention (the site
+       sets fill via CSS): the pill outline as a filled ring + the "on" knob. -->
+  <path fill-rule="evenodd" d="M7 5.5h10a6.5 6.5 0 0 1 0 13H7a6.5 6.5 0 0 1 0-13Zm0 2a4.5 4.5 0 0 0 0 9h10a4.5 4.5 0 0 0 0-9H7Z"/>
+  <circle cx="16.5" cy="12" r="3.3"/>
+</svg>


### PR DESCRIPTION
  ## This PR

  - Adds [Switchbox](https://switchbox.dev), a feature flag service with CDN-based delivery, to
  the providers catalog
  - Switchbox ships official OpenFeature providers wrapping its SDKs:
    - [`@switchbox/openfeature`](https://www.npmjs.com/package/@switchbox/openfeature) for the
  web SDK (JavaScript, works with the React SDK)
    - [`switchbox-openfeature`](https://pypi.org/project/switchbox-openfeature/) for Python
  - Docs: https://switchbox.dev/docs/sdk/openfeature

  ### Notes

  I'm the vendor (solo maintainer of Switchbox). The logo follows the colorless `*-no-fill.svg`
  convention. Entries follow the existing dataset shape (see `configcat.ts`): JavaScript and
  React under Client, Python under Server, all `vendorOfficial: true`.

  ### How to test

  `yarn start`, open `/ecosystem`, and search "switchbox": three cards should appear
  (JavaScript Web Provider, React Web Provider, Python Server Provider) with the Switchbox
  toggle mark rendering in both light and dark themes.

  Delete the "Related Issues" and "Follow-up Tasks" sections — there's no linked issue and
  nothing pending.

  I verified everything the "How to test" section claims when I built it locally (ESLint pass,
  full Docusaurus build, and the ecosystem page screenshot with all three cards), so a reviewer
  following it will see exactly that.

