### PR TITLE
Add Featureflip provider to the ecosystem

### DIFF
--- a/src/datasets/providers/featureflip.ts
+++ b/src/datasets/providers/featureflip.ts
@@ -1,0 +1,22 @@
+import FeatureflipSvg from '@site/static/img/featureflip-no-fill.svg';
+
+import { Provider } from '.';
+
+export const Featureflip: Provider = {
+  name: 'Featureflip',
+  logo: FeatureflipSvg,
+  technologies: [
+    {
+      technology: 'JavaScript',
+      vendorOfficial: true,
+      href: 'https://featureflip.io/docs/integrations/openfeature/',
+      category: ['Server'],
+    },
+    {
+      technology: '.NET',
+      vendorOfficial: true,
+      href: 'https://featureflip.io/docs/integrations/openfeature/',
+      category: ['Server'],
+    },
+  ],
+};

--- a/src/datasets/providers/index.ts
+++ b/src/datasets/providers/index.ts
@@ -26,6 +26,7 @@ import { Split } from './split';
 import { Unleash } from './unleash';
 import { Statsig } from './statsig';
 import { FeatBit } from './featbit';
+import { Featureflip } from './featureflip';
 import { UserDefaults } from './user-defaults';
 import { GrowthBook } from './growthbook';
 import { MultiProvider } from './multi-provider';
@@ -65,6 +66,7 @@ export const PROVIDERS: Provider[] = [
   DevCycle,
   EnvVar,
   FeatBit,
+  Featureflip,
   Flagd,
   Flagsmith,
   Flipswitch,

--- a/static/img/featureflip-no-fill.svg
+++ b/static/img/featureflip-no-fill.svg
@@ -1,0 +1,4 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+  <rect x="3" y="2" width="2" height="20" rx="1" />
+  <path d="M4 15s1-1 4-1 5 2 8 2 4-1 4-1V3s-1 1-4 1-5-2-8-2-4 1-4 1z" />
+</svg>


### PR DESCRIPTION
This adds [Featureflip](https://featureflip.io) to the provider ecosystem.

Featureflip maintains official OpenFeature providers for its server SDKs, exposing Featureflip flag evaluation through the vendor-neutral OpenFeature API:

| Technology | Category | Artifact |
| --- | --- | --- |
| JavaScript / TypeScript | Server (Node.js) | [`@featureflip/openfeature-node`](https://www.npmjs.com/package/@featureflip/openfeature-node) |
| .NET | Server | [`Featureflip.OpenFeature`](https://www.nuget.org/packages/Featureflip.OpenFeature) |

- **Maintainer:** Vendor (official)
- **Docs:** https://featureflip.io/docs/integrations/openfeature/

Added `src/datasets/providers/featureflip.ts`, registered it in `providers/index.ts`, and included a monochrome `static/img/featureflip-no-fill.svg`.
