### PR TITLE
feat: add Flagsmith Kotlin provider

### DIFF
--- a/src/datasets/providers/flagsmith.ts
+++ b/src/datasets/providers/flagsmith.ts
@@ -30,6 +30,12 @@ export const Flagsmith: Provider = {
       category: ['Server'],
     },
     {
+      technology: 'Kotlin',
+      vendorOfficial: true,
+      href: 'https://github.com/Flagsmith/flagsmith-openfeature-provider-kotlin',
+      category: ['Client'],
+    },
+    {
       technology: '.NET',
       vendorOfficial: true,
       href: 'https://github.com/open-feature/dotnet-sdk-contrib/tree/main/src/OpenFeature.Contrib.Providers.Flagsmith',


### PR DESCRIPTION
## This PR

Adds the Flagsmith provider for the OpenFeature Kotlin SDK to the ecosystem catalog.

- Repository: https://github.com/Flagsmith/flagsmith-openfeature-provider-kotlin (v0.1.0)
- Vendor-official, category Client, matching other Kotlin/Android providers.

### How to test

Run `yarn start`, open `/ecosystem`, filter by Kotlin: a Flagsmith card should appear.
