### PR TITLE
fix(docs): correct grammatical errors and improve clarity in documentation

### DIFF
--- a/docs/reference/concepts/01-evaluation-api.mdx
+++ b/docs/reference/concepts/01-evaluation-api.mdx
@@ -158,7 +158,7 @@ const boolValue = await client.getBooleanValue('boolFlag', false);
 // get a string value
 const stringValue = await client.getStringValue('stringFlag', 'default');
 
-// get an numeric value
+// get a numeric value
 const numberValue = await client.getNumberValue('intFlag', 1);
 
 // get an object value
@@ -198,7 +198,7 @@ var stringValue = await client.GetStringValue("stringFlag", "default");
 // get an integer value
 var intValue = await client.GetIntegerValue("intFlag", 1);
 
-// get an double value
+// get a double value
 var doubleValue = await client.GetDoubleValue("doubleFlag", 1);
 
 // get an object value
@@ -387,19 +387,19 @@ $objectDetails = $client->getObjectDetails("objectFlag", $myObjectInstance, null
 
 ```python
 # get details of boolean evaluation
-details = client.get_boolean_details("boolFlag", false);
+details = client.get_boolean_details("boolFlag", False)
 
 # get details of string evaluation
-details = client.get_string_details("stringFlag", "default");
+details = client.get_string_details("stringFlag", "default")
 
 # get details of an integer evaluation
-details = client.get_integer_details("intFlag", 1);
+details = client.get_integer_details("intFlag", 1)
 
 # get details of a float evaluation
-details = client.get_float_details("floatFlag", 1);
+details = client.get_float_details("floatFlag", 1)
 
 # get details of object evaluation
-details = client.get_object_details("objectFlag", {});
+details = client.get_object_details("objectFlag", {})
 ```
 
 </TabItem>

--- a/docs/reference/concepts/02-provider.mdx
+++ b/docs/reference/concepts/02-provider.mdx
@@ -57,7 +57,7 @@ The following naming recommendations can be used to ensure consistency between p
 
 #### Repository name
 
-If you're creating a new repository, it's recommended that you use one the following naming conventions:
+If you're creating a new repository, it's recommended that you use one of the following naming conventions:
 
 - `openfeature-provider-<language name>`
 - `<vendor/tool name>-openfeature-provider-<language name>`

--- a/docs/reference/concepts/03-evaluation-context.mdx
+++ b/docs/reference/concepts/03-evaluation-context.mdx
@@ -10,7 +10,7 @@ import TabItem from '@theme/TabItem';
 
 The [_evaluation context_](/specification/glossary#evaluation-context) is a container for arbitrary contextual data that can be used as a basis for dynamic evaluation.
 Static data such as the host or an identifier for the application can be configured globally.
-Dynamic evaluation context, such as the IP address of the client in a web application, can be implicitly propagated or explicitly passed to during flag evaluation, and can be merged with static values.
+Dynamic evaluation context, such as the IP address of the client in a web application, can be implicitly propagated or explicitly passed during flag evaluation, and can be merged with static values.
 
 ```mdx-code-block
 import LiteYouTubeEmbed from 'react-lite-youtube-embed';
@@ -124,7 +124,7 @@ boolValue, err := client.BooleanValue("boolFlag", false, evalCtx)
 
 ```php
 // add a value to the global context
-$api = OpenFeatureAPI.getInstance();
+$api = OpenFeatureAPI::getInstance();
 $api->setEvaluationContext(new EvaluationContext("targetingKey", ["myGlobalKey" => "myGlobalValue"]));
 
 // add a value to the client context

--- a/docs/reference/concepts/04-hooks.mdx
+++ b/docs/reference/concepts/04-hooks.mdx
@@ -100,7 +100,7 @@ value, err := client.BooleanValue(
 
 ```php
 // add a hook globally, to run on all evaluations
-$api = OpenFeatureAPI.getInstance();
+$api = OpenFeatureAPI::getInstance();
 $api->addHook(new ExampleGlobalHook());
 
 // add a hook on this client, to run on all evaluations made by this client

--- a/docs/reference/concepts/05-events.mdx
+++ b/docs/reference/concepts/05-events.mdx
@@ -31,7 +31,7 @@ client.addHandler(ProviderEvents.ConfigurationChanged, (eventDetails) => {
 
 // add an event handler to the global API
 OpenFeature.addHandler(ProviderEvents.Error, (eventDetails) => {
-  // do something when if the provider goes into an error state
+  // do something when the provider goes into an error state
 });
 ```
 
@@ -47,7 +47,7 @@ client.onProviderConfigurationChanged((EventDetails eventDetails) -> {
 
 // add an event handler to the global API
 OpenFeatureAPI.getInstance().onProviderError((EventDetails eventDetails) -> {
-  // do something when if the provider goes into an error state
+  // do something when the provider goes into an error state
 });
 ```
 
@@ -66,7 +66,7 @@ client.AddHandler(ProviderEventTypes.ProviderConfigurationChanged, (ProviderEven
 // add an event handler to the global API
 Api.Instance.AddHandler(ProviderEventTypes.ProviderError, (ProviderEventPayload eventDetails) =>
 {
-  // do something when if the provider goes into an error state
+  // do something when the provider goes into an error state
 });
 ```
 
@@ -85,7 +85,7 @@ client := openfeature.NewClient("clientName")
 client.AddHandler(openfeature.ProviderError, &changedCallback)
 
 var errorCallback = func(details openfeature.EventDetails) {
-  // do something when if the provider goes into an error state
+  // do something when the provider goes into an error state
 }
 
 // add an event handler to the global API
@@ -106,7 +106,7 @@ def on_changed(event_details: EventDetails):
 client.add_handler(ProviderEvent.PROVIDER_CONFIGURATION_CHANGED, on_changed)
 
 def on_error(event_details: EventDetails):
-  # do something when if the provider goes into an error state
+  # do something when the provider goes into an error state
 
 # add an event handler to the global API
 api.add_handler(ProviderEvent.PROVIDER_ERROR, on_error)
@@ -146,7 +146,7 @@ Handlers associated with `PROVIDER_ERROR` events can be used to alert monitoring
 
 The provider's cached state is no longer valid and may not be up-to-date with the source of truth.
 
-Some providers maintain a connection to a management system, but are also tolerate of disconnection.
+Some providers maintain a connection to a management system, but are also tolerant of disconnection.
 The `PROVIDER_STALE` indicates this situation.
 
 ### PROVIDER_RECONCILING (Static-context/Client-side only)

--- a/docs/reference/concepts/06-sdk-paradigms.mdx
+++ b/docs/reference/concepts/06-sdk-paradigms.mdx
@@ -19,7 +19,7 @@ For this reason, the evaluation API defines a parameter for the evaluation conte
 
 In client-side usage, the evaluation context changes less frequently, often in response to user actions or UI events.
 In this case, the context frequently corresponds to a single user, and the context data represents facts about them (such as their name or subscription level) or the application state (if the user has items in their cart).
-When the context data changes, it's often necessary for the provider to update it's cache of evaluated flags, or request an updated ruleset from the server; we refer to this as _context reconciliation_.
+When the context data changes, it's often necessary for the provider to update its cache of evaluated flags, or request an updated ruleset from the server; we refer to this as _context reconciliation_.
 SDKs using the static-context paradigm define a `context changed handler` for providers to implement which runs any time the context is modified.
 Client-side implementations include some additional event types: [PROVIDER_RECONCILING](/docs/reference/concepts/events#provider_reconciling-static-contextclient-side-only) and [PROVIDER_CONTEXT_CHANGED](/docs/reference/concepts/events#provider_context_changed-static-contextclient-side-only).
 These are emitted when the provider's context is invalidated, and after it's subsequently reconciled, accordingly.

--- a/docs/reference/concepts/07-tracking.mdx
+++ b/docs/reference/concepts/07-tracking.mdx
@@ -28,7 +28,7 @@ Tracking creates a crucial link between flag evaluations and business outcomes, 
 Experimentation differs from generalized
 Performance Monitoring in its execution.
 The most common form of Experimentation being A/B testing which is when two variations of an application or feature
-are distributed randomly to similar groups and the differences in metrics is evaluated.
+are distributed randomly to similar groups and the differences in metrics are evaluated.
 For example, if a feature flag controls the order
 of items in a menu, tracking events can be emitted when users click on menu items.
 The feature flag provider can typically be set to distribute the different variations

--- a/docs/reference/intro.mdx
+++ b/docs/reference/intro.mdx
@@ -71,7 +71,7 @@ The evaluation API provides a framework that allows for customization of behavio
 
 The [evaluation context](./concepts/03-evaluation-context.mdx) is a container for arbitrary contextual data that can be used as a basis for dynamic evaluation.
 Static data such as the host or an identifier for the application can be configured globally.
-Dynamic evaluation context, such as the IP address of the client in a web application, can be implicitly propagated or explicitly passed to during flag evaluation, and can be merged with static values.
+Dynamic evaluation context, such as the IP address of the client in a web application, can be implicitly propagated or explicitly passed during flag evaluation, and can be merged with static values.
 
 ### Providers
 

--- a/docs/reference/sdks/client/web/react.mdx
+++ b/docs/reference/sdks/client/web/react.mdx
@@ -280,7 +280,7 @@ For more information about `domains`, refer to the [web SDK](https://github.com/
 #### Re-rendering with Context Changes
 
 By default, if the OpenFeature [evaluation context](/docs/reference/concepts/evaluation-context) is modified, components will be re-rendered.
-This is useful in cases where flag values are dependant on user-attributes or other application state (user logged in, items in card, etc).
+This is useful in cases where flag values are dependent on user-attributes or other application state (user logged in, items in cart, etc).
 You can disable this feature in the hook options (or in the [OpenFeatureProvider](#openfeatureprovider-context-provider)):
 
 ```tsx

--- a/docs/reference/sdks/server/cpp.mdx
+++ b/docs/reference/sdks/server/cpp.mdx
@@ -237,7 +237,7 @@ class MyProvider : public openfeature::FeatureProvider {
   std::unique_ptr<openfeature::IntResolutionDetails> GetIntegerEvaluation(
       std::string_view flag, int64_t default_value,
       const openfeature::EvaluationContext& ctx) override {
-        // resolve a int flag value
+        // resolve an int flag value
       }
 
   std::unique_ptr<openfeature::DoubleResolutionDetails> GetDoubleEvaluation(
@@ -249,7 +249,7 @@ class MyProvider : public openfeature::FeatureProvider {
   std::unique_ptr<openfeature::ObjectResolutionDetails> GetObjectEvaluation(
       std::string_view flag, Value default_value,
       const openfeature::EvaluationContext& ctx) override {
-        // resolve a object flag value
+        // resolve an object flag value
       }
 };
 ```

--- a/docs/reference/sdks/server/ruby.mdx
+++ b/docs/reference/sdks/server/ruby.mdx
@@ -467,7 +467,7 @@ class MyProvider
   end
 
   def fetch_integer_value(flag_key:, default_value:, evaluation_context: nil)
-    # Retrieve a integer value from provider source
+    # Retrieve an integer value from provider source
   end
 
   def fetch_float_value(flag_key:, default_value:, evaluation_context: nil)


### PR DESCRIPTION
## This PR

- Fixes grammar, spelling, and typos across the reference documentation, and corrects two broken code examples.

## Related Issues

_None._ (No tracking issue — small documentation cleanup.)

## Notes

- Two of the changes are genuine code-example bugs (PHP `::` static call, Python `False`), not just wording — the snippets would fail as previously written.

## Follow-up Tasks

## How to test

- No functional testing needed — documentation only.
- Optional: `yarn build` (Docusaurus) to confirm the MDX still compiles, and `yarn lint:md` for markdownlint.
