### PR TITLE
feat: add Rollgate provider

### DIFF
--- a/src/datasets/providers/index.ts
+++ b/src/datasets/providers/index.ts
@@ -22,6 +22,7 @@ import { Mixpanel } from './mixpanel';
 import { PostHog } from './posthog';
 import { Prefab } from './prefab';
 import { Reflag } from './reflag';
+import { Rollgate } from './rollgate';
 import { Split } from './split';
 import { Switchbox } from './switchbox';
 import { Unleash } from './unleash';
@@ -83,6 +84,7 @@ export const PROVIDERS: Provider[] = [
   PostHog,
   Prefab,
   Reflag,
+  Rollgate,
   Split,
   Statsig,
   Switchbox,

--- a/src/datasets/providers/rollgate.ts
+++ b/src/datasets/providers/rollgate.ts
@@ -1,0 +1,15 @@
+import RollgateSvg from '@site/static/img/rollgate.svg';
+import { Provider } from '.';
+
+export const Rollgate: Provider = {
+  name: 'Rollgate',
+  logo: RollgateSvg,
+  technologies: [
+    {
+      technology: 'JavaScript',
+      vendorOfficial: true,
+      href: 'https://github.com/rollgate/sdks/tree/main/packages/openfeature-server-provider',
+      category: ['Server'],
+    },
+  ],
+};

--- a/static/img/rollgate.svg
+++ b/static/img/rollgate.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <rect width="32" height="32" rx="6" fill="#f59e0b"/>
+  <path d="M9 10h6v4h-2v4h-4v-8zm0 12v-4h4v4h-4zm8-12h6v12h-4v-8h-2v-4z" fill="#18181b"/>
+</svg>


### PR DESCRIPTION
Adds **Rollgate** to the provider ecosystem list.

## Provider

[`@rollgate/openfeature-server-provider`](https://www.npmjs.com/package/@rollgate/openfeature-server-provider) (npm, v0.1.0) — JavaScript / Server, vendor-official. Wraps [`@rollgate/sdk-node`](https://www.npmjs.com/package/@rollgate/sdk-node), mapping its detailed evaluation API onto the `@openfeature/server-sdk` `Provider` contract.

Source: https://github.com/rollgate/sdks/tree/main/packages/openfeature-server-provider

## Checklist

- [x] All resolution methods implemented (boolean / string / number / object)
- [x] Context transformation documented (`targetingKey` → Rollgate `userId`, flat attributes; `Date` → ISO)
- [x] Reason & error-code mapping to OpenFeature standards; `variant` + `flagMetadata` exposed; `TYPE_MISMATCH` on unexpected type
- [x] Adequately tested (18 unit tests)
- [x] Provider releases follow semantic versioning (0.1.0)
- [x] Named per conventions

Server provider only for now; a web provider (`@openfeature/web-sdk`) is planned.