### PR TITLE
chore: resolve open dependabot security alerts

### DIFF
--- a/package.json
+++ b/package.json
@@ -178,6 +178,7 @@
     "styled-components/postcss": "^8.5.10",
     "webpack": "5.104.1",
     "fast-uri": ">=3.1.2",
-    "@babel/plugin-transform-modules-systemjs": ">=7.29.4"
+    "@babel/plugin-transform-modules-systemjs": ">=7.29.4",
+    "ip-address": "^10.3.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -11187,10 +11187,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ip-address@npm:^10.0.1":
-  version: 10.2.0
-  resolution: "ip-address@npm:10.2.0"
-  checksum: 10c0/5a00aada6e922c9c69dfc800ed5d0fa3348675ebdeed0e1575f503f27ca385b5f534363c9af7ad1daf64c1f1409388cdd3cc2e9b9b0fe1c924a431378d55075a
+"ip-address@npm:^10.3.1":
+  version: 10.4.0
+  resolution: "ip-address@npm:10.4.0"
+  checksum: 10c0/d7b0bd2624fd861afbae6e49036a9b56f9506eaff7ff38592b7b4492dd5c272b53f5356dc8cc019e318acf29a96c90a3d1af1df761960267d23efa96858270fa
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- Resolved 3 open Dependabot security alerts by adding a yarn resolution forcing `ip-address` to a patched version

## Dependabot Alerts Resolved

| Alert | Package | Severity | Fix |
|-------|---------|----------|-----|
| #273 | `ip-address` | **high** | Added resolution forcing `ip-address` to `^10.3.1` (resolves to 10.4.0), fixing the transitive dependency pulled in via `socks` |
| #272 | `ip-address` | **medium** | Same resolution as above |
| #271 | `ip-address` | **medium** | Same resolution as above |

## Skipped (unresolvable)

- Alert #80 (`tsup`, low severity, DOM Clobbering) has no patched version published upstream yet, so it cannot be fixed at this time.