### PR TITLE
feat: add Featurevisor OpenFeature providers

### DIFF
--- a/src/datasets/providers/featurevisor.ts
+++ b/src/datasets/providers/featurevisor.ts
@@ -1,0 +1,58 @@
+import FeaturevisorSvg from '@site/static/img/featurevisor-no-fill.svg';
+
+import type { Provider } from '.';
+
+export const Featurevisor: Provider = {
+  name: 'Featurevisor',
+  logo: FeaturevisorSvg,
+  technologies: [
+    {
+      technology: 'JavaScript',
+      vendorOfficial: true,
+      href: 'https://featurevisor.com/docs/sdks/browser/#open-feature',
+      category: ['Client'],
+    },
+    {
+      technology: 'JavaScript',
+      vendorOfficial: true,
+      href: 'https://featurevisor.com/docs/sdks/nodejs/#open-feature',
+      category: ['Server'],
+    },
+    {
+      technology: 'Go',
+      vendorOfficial: true,
+      href: 'https://featurevisor.com/docs/sdks/go/#open-feature',
+      category: ['Server'],
+    },
+    {
+      technology: 'Swift',
+      vendorOfficial: true,
+      href: 'https://featurevisor.com/docs/sdks/swift/#open-feature',
+      category: ['Client'],
+    },
+    {
+      technology: 'Java',
+      vendorOfficial: true,
+      href: 'https://featurevisor.com/docs/sdks/java/#open-feature',
+      category: ['Server'],
+    },
+    {
+      technology: 'Ruby',
+      vendorOfficial: true,
+      href: 'https://featurevisor.com/docs/sdks/ruby/#open-feature',
+      category: ['Server'],
+    },
+    {
+      technology: 'Python',
+      vendorOfficial: true,
+      href: 'https://featurevisor.com/docs/sdks/python/#open-feature',
+      category: ['Server'],
+    },
+    {
+      technology: 'PHP',
+      vendorOfficial: true,
+      href: 'https://featurevisor.com/docs/sdks/php/#open-feature',
+      category: ['Server'],
+    },
+  ],
+};

--- a/src/datasets/providers/index.ts
+++ b/src/datasets/providers/index.ts
@@ -29,6 +29,7 @@ import { Unleash } from './unleash';
 import { Statsig } from './statsig';
 import { FeatBit } from './featbit';
 import { Featureflip } from './featureflip';
+import { Featurevisor } from './featurevisor';
 import { UserDefaults } from './user-defaults';
 import { GrowthBook } from './growthbook';
 import { MultiProvider } from './multi-provider';
@@ -70,6 +71,7 @@ export const PROVIDERS: Provider[] = [
   EnvVar,
   FeatBit,
   Featureflip,
+  Featurevisor,
   Flagd,
   Flagsmith,
   Flipswitch,

--- a/static/img/featurevisor-no-fill.svg
+++ b/static/img/featurevisor-no-fill.svg
@@ -1,4 +1,3 @@
-<svg viewBox="0 0 800 680" xmlns="http://www.w3.org/2000/svg">
-  <path fill-rule="evenodd" d="M0 0h800L400 680zM42 24L400 632h358z" />
-  <path d="M172 100h440l-45 77H306l43 75h175l-45 77H393l43 76-45 76z" />
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 784 681">
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M0 0H784L392 680.5ZM41.9 23.5H742.1L392 632ZM173 100H610L567 175.5H305.5L349.5 251.5H522L479 327.5H392.5L435.8 402.8L391.6 479.7Z"/>
 </svg>

--- a/static/img/featurevisor-no-fill.svg
+++ b/static/img/featurevisor-no-fill.svg
@@ -1,0 +1,4 @@
+<svg viewBox="0 0 800 680" xmlns="http://www.w3.org/2000/svg">
+  <path fill-rule="evenodd" d="M0 0h800L400 680zM42 24L400 632h358z" />
+  <path d="M172 100h440l-45 77H306l43 75h175l-45 77H393l43 76-45 76z" />
+</svg>


### PR DESCRIPTION
## Summary
- Add Featurevisor to the provider catalog.
- Add official JavaScript, Go, Swift, Java, Ruby, Python, and PHP provider links.
- Add a geometry-only Featurevisor logo asset.

## Reference
https://featurevisor.com/blog/openfeature-providers/