### PR TITLE
feat: add Quonfig provider

### DIFF
--- a/src/datasets/providers/index.ts
+++ b/src/datasets/providers/index.ts
@@ -41,6 +41,7 @@ import { OFREP } from './ofrep';
 import { VWO } from './vwo';
 import { SDKS } from '../sdks';
 import { Intellitoggle } from './intellitoggle';
+import { Quonfig } from './quonfig';
 
 const childTechnologyMap = SDKS.reduce(
   (acc, sdk) => {
@@ -97,6 +98,7 @@ export const PROVIDERS: Provider[] = [
   OFREP,
   VWO,
   Intellitoggle,
+  Quonfig,
 ];
 
 // Map of provider name to technology to child technologies

--- a/src/datasets/providers/quonfig.ts
+++ b/src/datasets/providers/quonfig.ts
@@ -1,0 +1,40 @@
+import QuonfigSvg from '@site/static/img/quonfig-no-fill.svg';
+
+import { Provider } from '.';
+
+export const Quonfig: Provider = {
+  name: 'Quonfig',
+  logo: QuonfigSvg,
+  technologies: [
+    {
+      technology: 'Go',
+      vendorOfficial: true,
+      href: 'https://github.com/quonfig/openfeature-go',
+      category: ['Server'],
+    },
+    {
+      technology: 'JavaScript',
+      vendorOfficial: true,
+      href: 'https://github.com/quonfig/openfeature-node',
+      category: ['Server'],
+    },
+    {
+      technology: 'JavaScript',
+      vendorOfficial: true,
+      href: 'https://github.com/quonfig/openfeature-web',
+      category: ['Client'],
+    },
+    {
+      technology: 'Python',
+      vendorOfficial: true,
+      href: 'https://github.com/quonfig/openfeature-python',
+      category: ['Server'],
+    },
+    {
+      technology: 'Ruby',
+      vendorOfficial: true,
+      href: 'https://github.com/quonfig/openfeature-ruby',
+      category: ['Server'],
+    },
+  ],
+};

--- a/static/img/quonfig-no-fill.svg
+++ b/static/img/quonfig-no-fill.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48">
+  <path d="m8 8 16 16L8 40l-4-4 12-12L4 12l4-4Zm19 4h8v24h-8V12Z"/>
+</svg>


### PR DESCRIPTION
## Summary

- Add Quonfig's official Go, Node.js, web, Python, and Ruby OpenFeature providers.
- Add separate JavaScript entries for the server and browser providers.
- Add the Quonfig provider logo.

## Provider Coverage

| Technology | Category | Source |
| --- | --- | --- |
| Go | Server | https://github.com/quonfig/openfeature-go |
| JavaScript | Server | https://github.com/quonfig/openfeature-node |
| JavaScript | Client | https://github.com/quonfig/openfeature-web |
| Python | Server | https://github.com/quonfig/openfeature-python |
| Ruby | Server | https://github.com/quonfig/openfeature-ruby |

## References

- https://docs.quonfig.com/docs/category/openfeature-providers
- https://quonfig.com