### PR TITLE
feat: add PostHog JavaScript and Python providers

### DIFF
--- a/src/datasets/providers/posthog.ts
+++ b/src/datasets/providers/posthog.ts
@@ -7,6 +7,24 @@ export const PostHog: Provider = {
   technologies: [
     {
       technology: 'JavaScript',
+      vendorOfficial: true,
+      href: 'https://github.com/PostHog/posthog-js/tree/main/packages/openfeature-node-provider',
+      category: ['Server'],
+    },
+    {
+      technology: 'JavaScript',
+      vendorOfficial: true,
+      href: 'https://github.com/PostHog/posthog-js/tree/main/packages/openfeature-web-provider',
+      category: ['Client'],
+    },
+    {
+      technology: 'Python',
+      vendorOfficial: true,
+      href: 'https://github.com/PostHog/posthog-python/tree/main/openfeature-provider',
+      category: ['Server'],
+    },
+    {
+      technology: 'JavaScript',
       vendorOfficial: false,
       href: 'https://www.npmjs.com/package/@tapico/node-openfeature-posthog',
       category: ['Server'],


### PR DESCRIPTION
## Summary

- Add PostHog's official Node.js OpenFeature provider.
- Add PostHog's official browser OpenFeature provider.
- Add PostHog's official Python OpenFeature provider.