### PR TITLE
feat: add CloudBees provider variants

### DIFF
--- a/src/datasets/providers/cloudbees.ts
+++ b/src/datasets/providers/cloudbees.ts
@@ -8,19 +8,31 @@ export const CloudBees: Provider = {
     {
       technology: 'JavaScript',
       vendorOfficial: true,
-      href: 'https://github.com/rollout/cloudbees-openfeature-provider-node',
+      href: 'https://github.com/cloudbees-oss/cloudbees-openfeature-provider-node',
       category: ['Server'],
+    },
+    {
+      technology: 'JavaScript',
+      vendorOfficial: true,
+      href: 'https://github.com/cloudbees-oss/cloudbees-openfeature-provider-browser',
+      category: ['Client'],
     },
     {
       technology: 'Go',
       vendorOfficial: true,
-      href: 'https://github.com/rollout/cloudbees-openfeature-provider-go',
+      href: 'https://github.com/cloudbees-oss/cloudbees-openfeature-provider-go',
       category: ['Server'],
     },
     {
       technology: 'Java',
       vendorOfficial: true,
-      href: 'https://github.com/rollout/cloudbees-openfeature-provider-java',
+      href: 'https://github.com/cloudbees-oss/cloudbees-openfeature-provider-java',
+      category: ['Server'],
+    },
+    {
+      technology: '.NET',
+      vendorOfficial: true,
+      href: 'https://github.com/cloudbees-oss/cloudbees-openfeature-provider-dotnet',
       category: ['Server'],
     },
     {
@@ -32,7 +44,7 @@ export const CloudBees: Provider = {
     {
       technology: 'Python',
       vendorOfficial: true,
-      href: 'https://github.com/rollout/cloudbees-openfeature-provider-python',
+      href: 'https://github.com/cloudbees-oss/cloudbees-openfeature-provider-python',
       category: ['Server'],
     },
   ],


### PR DESCRIPTION
## Summary

- Add the official CloudBees browser and .NET OpenFeature providers.
- Update the Node.js, Go, Java, and Python links to the canonical  repositories.
- Preserve the community PHP provider entry.

## Verification

- Confirmed all provider URLs return HTTP 200.
- Ran ESLint on .
- Ran  and the SVG paint-declaration check.

## Sources

- [CloudBees Feature Management documentation](https://docs.cloudbees.com/docs/cloudbees-feature-management/latest/)
- [CloudBees OSS provider repositories](https://github.com/cloudbees-oss)