### PR TITLE
Add Featureflip Python provider to the ecosystem

### DIFF
--- a/src/datasets/providers/featureflip.ts
+++ b/src/datasets/providers/featureflip.ts
@@ -18,5 +18,11 @@ export const Featureflip: Provider = {
       href: 'https://featureflip.io/docs/integrations/openfeature/',
       category: ['Server'],
     },
+    {
+      technology: 'Python',
+      vendorOfficial: true,
+      href: 'https://featureflip.io/docs/integrations/openfeature/',
+      category: ['Server'],
+    },
   ],
 };


### PR DESCRIPTION
Adds the Featureflip **Python** provider to the ecosystem, alongside the existing JavaScript and .NET entries added in #1410.

- Package: [`featureflip-openfeature-provider`](https://pypi.org/project/featureflip-openfeature-provider/) on PyPI
- Docs: https://featureflip.io/docs/integrations/openfeature/
- Vendor-official, server-side

Only `src/datasets/providers/featureflip.ts` changes — the logo and the `PROVIDERS[]` registration already landed with the original entry.
