### PR TITLE
feat: add UseFlagly provider and OFREP API to ecosystem

### DIFF
--- a/src/datasets/ofrep-api/index.ts
+++ b/src/datasets/ofrep-api/index.ts
@@ -7,9 +7,10 @@ import { Flagd } from './flagd';
 import { ConfigCat } from './configcat';
 import { FFlags } from './fflags';
 import { Flipswitch } from './flipswitch';
+import { UseFlagly } from './useflagly';
 export type OFREPElement = Omit<EcosystemElement, 'allTechnologies' | 'technology' | 'category'>;
 
-export const ECOSYSTEM_OFREP_APIS: OFREPElement[] = [ConfigCat, DevCycle, Flagd, FFlags, Flipswitch, Flipt, Goff]
+export const ECOSYSTEM_OFREP_APIS: OFREPElement[] = [ConfigCat, DevCycle, Flagd, FFlags, Flipswitch, Flipt, Goff, UseFlagly]
   .map(
     (api): OFREPElement => ({
       vendor: api.name,

--- a/src/datasets/ofrep-api/useflagly.ts
+++ b/src/datasets/ofrep-api/useflagly.ts
@@ -1,0 +1,10 @@
+import UseFlaglySvg from '@site/static/img/useflagly-no-fill.svg';
+import { OFREP_API } from '.';
+
+export const UseFlagly: OFREP_API = {
+  name: 'UseFlagly',
+  logo: UseFlaglySvg,
+  description: 'UseFlagly Remote Evaluation API implementation of the OFREP specification',
+  href: 'https://www.useflagly.com.br',
+  vendorOfficial: true,
+};

--- a/src/datasets/providers/index.ts
+++ b/src/datasets/providers/index.ts
@@ -50,6 +50,7 @@ import { OctopusDeploy } from './octopus-deploy';
 import { Optimizely } from './optimizely';
 import { Pendo } from './pendo';
 import { Superposition } from './superposition';
+import { UseFlagly } from './useflagly';
 
 const childTechnologyMap = SDKS.reduce(
   (acc, sdk) => {
@@ -114,7 +115,8 @@ export const PROVIDERS: Provider[] = [
   OctopusDeploy,
   Optimizely,
   Pendo,
-  Superposition
+  Superposition,
+  UseFlagly,
 ];
 
 // Map of provider name to technology to child technologies

--- a/src/datasets/providers/useflagly.ts
+++ b/src/datasets/providers/useflagly.ts
@@ -1,0 +1,16 @@
+import UseFlaglySvg from '@site/static/img/useflagly-no-fill.svg';
+
+import { Provider } from '.';
+
+export const UseFlagly: Provider = {
+  name: 'UseFlagly',
+  logo: UseFlaglySvg,
+  technologies: [
+    {
+      technology: 'JavaScript',
+      vendorOfficial: true,
+      href: 'https://www.npmjs.com/package/@useflagly/openfeature-provider',
+      category: ['Server'],
+    },
+  ],
+};

--- a/static/img/useflagly-no-fill.svg
+++ b/static/img/useflagly-no-fill.svg
@@ -1,0 +1,3 @@
+<svg viewBox="0 0 100 100" xmlns="http://www.w3.org/2000/svg">
+  <path d="M21 15a4 4 0 0 1 8 0v70a4 4 0 0 1-8 0V15zm4 3 48.5 14.2c3.5 1 3.5 5.6 0 6.6L25 53V18z"/>
+</svg>


### PR DESCRIPTION
## Description
Adds UseFlagly to the OpenFeature ecosystem directory:
- Official Node.js/TypeScript Provider: `@useflagly/openfeature-provider`
- OFREP API: Native support for OpenFeature Remote Evaluation Protocol at `https://api.useflagly.com.br/ofrep/v1`

## Package Link
- NPM: https://www.npmjs.com/package/@useflagly/openfeature-provider
- Website: https://www.useflagly.com.br
