### PR TITLE
Add Featureflip Go and Java providers to the ecosystem

### DIFF
--- a/src/datasets/providers/featureflip.ts
+++ b/src/datasets/providers/featureflip.ts
@@ -24,5 +24,11 @@ export const Featureflip: Provider = {
       href: 'https://featureflip.io/docs/integrations/openfeature/',
       category: ['Server'],
     },
+    {
+      technology: 'Go',
+      vendorOfficial: true,
+      href: 'https://featureflip.io/docs/integrations/openfeature/',
+      category: ['Server'],
+    },
   ],
 };

--- a/src/datasets/providers/featureflip.ts
+++ b/src/datasets/providers/featureflip.ts
@@ -30,5 +30,11 @@ export const Featureflip: Provider = {
       href: 'https://featureflip.io/docs/integrations/openfeature/',
       category: ['Server'],
     },
+    {
+      technology: 'Java',
+      vendorOfficial: true,
+      href: 'https://featureflip.io/docs/integrations/openfeature/',
+      category: ['Server'],
+    },
   ],
 };


### PR DESCRIPTION
Featureflip now ships official OpenFeature providers for **Go** and **Java**, alongside the existing JavaScript, .NET and Python entries. This adds both rows to the existing `Featureflip` provider entry — no new dataset file or logo needed.

**Go** — [`github.com/canopy-labs/featureflip-go-openfeature`](https://pkg.go.dev/github.com/canopy-labs/featureflip-go-openfeature) (v0.2.0, Apache-2.0)

Wraps the Featureflip Go server SDK behind `openfeature.FeatureProvider`, and also implements `StateHandler`, `Tracker` and `EventHandler` — so `PROVIDER_CONFIGURATION_CHANGED` is emitted when flag configuration changes.

**Java** — [`io.featureflip:featureflip-openfeature`](https://central.sonatype.com/artifact/io.featureflip/featureflip-openfeature) (0.1.0, Apache-2.0, Java 11+)

Wraps the Featureflip Java server SDK behind `dev.openfeature.sdk.EventProvider`. Boolean, string, integer, double and object resolution, tracking via `track`, and `PROVIDER_CONFIGURATION_CHANGED` on configuration changes.

**Docs for both:** https://featureflip.io/docs/integrations/openfeature/

The `href` points at the public documentation rather than a repository, matching the existing Featureflip rows.

*(The Java row was added to this PR rather than opened as a separate one, since it is the same one-file change to the same entry.)*