### PR TITLE
feat: add Flagsmith Swift provider

### DIFF
--- a/src/datasets/providers/flagsmith.ts
+++ b/src/datasets/providers/flagsmith.ts
@@ -59,5 +59,11 @@ export const Flagsmith: Provider = {
       href: 'https://github.com/open-feature/rust-sdk-contrib/tree/main/crates/flagsmith',
       category: ['Server'],
     },
+    {
+      technology: 'Swift',
+      vendorOfficial: true,
+      href: 'https://github.com/Flagsmith/flagsmith-openfeature-swift-provider',
+      category: ['Client'],
+    },
   ],
 };


### PR DESCRIPTION
Lists Flagsmith's Swift provider on the ecosystem page.

The provider is maintained by Flagsmith and works with the OpenFeature Swift SDK:
https://github.com/Flagsmith/flagsmith-openfeature-swift-provider
