### PR TITLE
feat: add Featureflip to commercial support list

### DIFF
--- a/src/datasets/support/commercial-support.ts
+++ b/src/datasets/support/commercial-support.ts
@@ -2,6 +2,7 @@ import type { ComponentType, SVGProps } from 'react';
 
 import KameleoonSvg from '@site/static/img/vendors/kameleoon.svg';
 import DevCycleSvg from '@site/static/img/vendors/devcycle.svg';
+import FeatureflipSvg from '@site/static/img/vendors/featureflip.svg';
 import FliptSvg from '@site/static/img/vendors/flipt.svg';
 import FlagsmithSvg from '@site/static/img/vendors/flagsmith.svg';
 import HarnessSvg from '@site/static/img/vendors/harness.svg';
@@ -36,6 +37,11 @@ export const CommercialSupportList: CommercialSupportType[] = [
     name: 'DevCycle',
     href: 'https://docs.devcycle.com/integrations/openfeature',
     svg: DevCycleSvg,
+  },
+  {
+    name: 'Featureflip',
+    href: 'https://featureflip.io/docs/integrations/openfeature/',
+    svg: FeatureflipSvg,
   },
   {
     name: 'Flagsmith',

--- a/static/img/vendors/featureflip.svg
+++ b/static/img/vendors/featureflip.svg
@@ -1,0 +1,4 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="#3b82f6" xmlns="http://www.w3.org/2000/svg">
+  <rect x="3" y="2" width="2" height="20" rx="1" />
+  <path d="M4 15s1-1 4-1 5 2 8 2 4-1 4-1V3s-1 1-4 1-5-2-8-2-4 1-4 1z" />
+</svg>


### PR DESCRIPTION
Adds Featureflip to the [commercial support list](https://openfeature.dev/support-training).

**Disclosure:** I work on Featureflip — self-submission. This PR was prepared with AI assistance; the AI co-author trailers are deliberately omitted from the commit so the DCO check passes, and the sign-off is Featureflip's own.

### Against the two documented requirements

> At least one supported provider listed in the OpenFeature ecosystem

✅ Featureflip currently lists **JavaScript, .NET and Python** providers in the ecosystem (added in #1410 and #1469). #1476 adds Go and Java and is open.

> Publicly available mention of OpenFeature support on the company's website or documentation

✅ https://featureflip.io/docs/integrations/openfeature/ (returns 200)

### Changes

- `src/datasets/support/commercial-support.ts` — entry added **alphabetically** between DevCycle and Flagsmith, per the file's own comment.
- `static/img/vendors/featureflip.svg` — new vendor logo. Same mark already accepted into this repo as `static/img/featureflip-no-fill.svg`, using our brand colour rather than `currentColor` to match the other vendor logos.

Happy to adjust the logo or wording.